### PR TITLE
Update attributes of StorageClasses

### DIFF
--- a/csi.tf
+++ b/csi.tf
@@ -191,6 +191,9 @@ resource "kubernetes_storage_class" "sn_default" {
   parameters = {
     type = "gp2"
   }
+  reclaim_policy = "Delete"
+  allow_volume_expansion = true
+  volume_binding_mode = "WaitForFirstConsumer"
 }
 
 resource "kubernetes_storage_class" "sn_ssd" {
@@ -201,4 +204,7 @@ resource "kubernetes_storage_class" "sn_ssd" {
   parameters = {
     type = "gp2"
   }
+  reclaim_policy = "Delete"
+  allow_volume_expansion = true
+  volume_binding_mode = "WaitForFirstConsumer"
 }


### PR DESCRIPTION
The `StorageClasses` defined in the [aws bootstrap scripts](https://github.com/streamnative/cloud-api-server/blob/master/data/bootstrap/aws/storageclass.yaml) actually inherit some values from the [base bootstrap scripts](https://github.com/streamnative/cloud-api-server/blob/master/data/bootstrap/bases/system/01-storage.yaml). Add missing values in the PR.