### PR TITLE
Added Calico to the cluster

### DIFF
--- a/calico.tf
+++ b/calico.tf
@@ -1,0 +1,33 @@
+resource "kubernetes_namespace" "calico" {
+  metadata {
+    name = "calico-system"
+  }
+  depends_on = [
+    module.eks
+  ]
+}
+
+resource "helm_release" "calico" {
+  atomic          = true
+  chart           = var.calico_helm_chart_name
+  cleanup_on_fail = true
+  name            = "tigera-operator"
+  namespace       = kubernetes_namespace.calico.id
+  repository      = var.calico_helm_chart_repository
+  timeout         = 120
+  version         = var.calico_helm_chart_version
+
+  set {
+    name  = "installation.kubernetesProvider"
+    value = "EKS"
+    type  = "string"
+  }
+
+  dynamic "set" {
+    for_each = var.calico_settings
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,30 @@ variable "aws_partition" {
   type        = string
 }
 
+variable "calico_helm_chart_name" {
+  default     = "tigera-operator"
+  description = "The name of the Helm chart in the repository for Calico, which is installed alongside the tigera-operator."
+  type        = string
+}
+
+variable "calico_helm_chart_repository" {
+  default     = "https://stevehipwell.github.io/helm-charts/"
+  description = "The repository containing the calico helm chart. We are currently using a community provided chart, which is a fork of the official chart published by Tigera. This chart isn't as opinionated about namespaces, and should be used until this issue is resolved https://github.com/projectcalico/calico/issues/4812"
+  type        = string
+}
+
+variable "calico_helm_chart_version" {
+  default     = "1.0.5"
+  description = "Helm chart version for Calico. Defaults to \"1.0.5\". See https://github.com/stevehipwell/helm-charts/tree/master/charts/tigera-operator for available version releases."
+  type        = string
+}
+
+variable "calico_settings" {
+  default     = {}
+  description = "Additional settings which will be passed to the Helm chart values. See https://github.com/stevehipwell/helm-charts/tree/master/charts/tigera-operator for available options."
+  type        = map(any)
+}
+
 variable "cert_manager_helm_chart_name" {
   default     = "cert-manager"
   description = "The name of the Helm chart in the repository for cert-manager."


### PR DESCRIPTION
This commit adds support to install Calico on the cluster, using a [forked helm chart](https://github.com/stevehipwell/helm-charts/tree/master/charts/tigera-operator) that [addresses some of the problems](https://github.com/projectcalico/calico/issues/4812) with the official chart provided by Tigera. 