### PR TITLE
Added missing extdns config; changed istio sources logic

### DIFF
--- a/external_dns.tf
+++ b/external_dns.tf
@@ -121,11 +121,14 @@ resource "helm_release" "external_dns" {
     type  = "string"
   }
 
-
-
   set {
     name  = "sources"
-    value = var.enable_istio_operator == true && var.enable_istio_sources == true ? "{service,ingress,istio-gateway,istio-virtualservice}" : "{service,ingress}"
+    value = var.disable_istio_sources == true ? "{service,ingress}" : "{service,ingress,istio-gateway,istio-virtualservice}"
+  }
+
+  set {
+    name  = "txtOwnerId"
+    value = module.eks.cluster_id
   }
 
   dynamic "set" {

--- a/variables.tf
+++ b/variables.tf
@@ -177,6 +177,12 @@ variable "disable_olm" {
   type        = bool
 }
 
+variable "disable_istio_sources" {
+  default     = false
+  description = "Disables Istio sources for the External DNS configuration. Set to \"false\" by default. Set to \"true\" for debugging External DNS or if Istio is disabled."
+  type        = bool
+}
+
 variable "enable_csi" {
   default     = true
   description = "Enables the EBS Container Storage Interface (CSI) driver on the cluster, which allows for EKS manage the lifecycle of persistant volumes in EBS."
@@ -186,12 +192,6 @@ variable "enable_csi" {
 variable "enable_istio_operator" {
   default     = true
   description = "Enables the Istio operator on the EKS cluster. Enabled by default."
-  type        = bool
-}
-
-variable "enable_istio_sources" {
-  default     = true
-  description = "Enables the Istio sources when deploying ExternalDNS. Automatically enabled if input \"enable_istio_operator\" is set to  \"true\", but can be explicitly disabled by setting this input to \"false\" and should only be changed for debugging purposes."
   type        = bool
 }
 
@@ -250,7 +250,7 @@ variable "external_dns_helm_chart_repository" {
 }
 
 variable "external_dns_helm_chart_version" {
-  default     = "4.9.0"
+  default     = "5.4.1"
   description = "Helm chart version for ExternalDNS. Defaults to \"4.9.0\". See https://hub.helm.sh/charts/bitnami/external-dns for updates."
   type        = string
 }


### PR DESCRIPTION
This PR adds and changes configuration for External DNS:

- Updated the helm chart to use the latest version, which installs v0.9.0 of External DNS
- Set `txtOwnerId` in the helm chart to be the name of the EKS cluster
- Changed `enable_istio_sources` to `disable_istio_sources`, which is set to `false` by default. This will allow control of the Istio sources independent of whether or not Istio is enabled on the cluster
- Readme updates
