### PR TITLE
Added kubernetes-external-secrets to the module

### DIFF
--- a/examples/example-with-full-bootstrap/main.tf
+++ b/examples/example-with-full-bootstrap/main.tf
@@ -156,7 +156,7 @@ module "sn_tiered_storage_vault_resources" {
   cluster_name         = module.sn_cluster.eks_cluster_id
   oidc_issuer          = module.sn_cluster.eks_cluster_oidc_issuer_string
   pulsar_namespace     = "my-pulsar-namespace" # The namespace where you will be installing Pulsar
-  service_account_name = "vault" # The name of the service account used by Vault in the Pulsar namespace
+  service_account_name = "vault"               # The name of the service account used by Vault in the Pulsar namespace
 
   tags = {
     Project     = "StreamNative Platform"

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -88,7 +88,7 @@ module "sn_cluster" {
       groups   = ["system:masters"]
     }
   ]
-  
+
   public_subnet_ids  = ["subnet-abcde012", "subnet-bcde012a", "subnet-fghi345a"]
   private_subnet_ids = ["subnet-vwxyz123", "subnet-efgh242a", "subnet-lmno643b"]
   region             = var.region

--- a/external_secrets.tf
+++ b/external_secrets.tf
@@ -1,0 +1,111 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+data "aws_iam_policy_document" "external_secrets" {
+  statement {
+    sid       = "ListSecrets"
+    actions   = ["secretsmanager:ListSecrets"]
+    resources = ["*"]
+    effect    = "Allow"
+  }
+
+  statement {
+    sid = "GetSecrets"
+    actions = [
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecretVersionIds",
+      "secretsmanager:ListSecrets",
+    ]
+    resources = coalescelist(var.asm_secret_arns, ["arn:aws:secretsmanager:${var.region}:${local.account_id}:secret:*"]) # Defaults to allow access to all secrets for ASM in the module's region
+    effect    = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "external_secrets_sts" {
+  statement {
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [format("arn:%s:iam::%s:oidc-provider/%s", var.aws_partition, local.account_id, local.oidc_issuer)]
+    }
+    condition {
+      test     = "StringLike"
+      values   = [format("system:serviceaccount:%s:%s", "sn-system", "external-secrets")]
+      variable = format("%s:sub", local.oidc_issuer)
+    }
+  }
+}
+
+resource "aws_iam_role" "external_secrets" {
+  count              = var.enable_external_secrets ? 1 : 0
+  name               = format("%s-external-secrets-role", module.eks.cluster_id)
+  description        = "Role assumed by EKS ServiceAccount external-secrets"
+  assume_role_policy = data.aws_iam_policy_document.external_secrets_sts.json
+
+  inline_policy {
+    name   = format("%s-external-secrets-policy", module.eks.cluster_id)
+    policy = data.aws_iam_policy_document.external_secrets.json
+  }
+}
+
+resource "helm_release" "external_secrets" {
+  count           = var.enable_external_secrets ? 1 : 0
+  atomic          = true
+  chart           = var.external_secrets_helm_chart_name
+  cleanup_on_fail = true
+  namespace       = join("", kubernetes_namespace.sn_system.*.id)
+  name            = "external-secrets"
+  repository      = var.external_secrets_helm_chart_repository
+  timeout         = 300
+  version         = var.external_secrets_helm_chart_version
+
+  set {
+    name  = "env.AWS_REGION"
+    value = var.region
+  }
+
+  set {
+    name  = "securityContext.fsGroup"
+    value = "65534"
+  }
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com\\/role\\-arn"
+    value = aws_iam_role.external_secrets[0].arn
+    type  = "string"
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = "external-secrets"
+  }
+
+  dynamic "set" {
+    for_each = var.external_secrets_settings
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+}

--- a/modules/tiered-storage-resources/main.tf
+++ b/modules/tiered-storage-resources/main.tf
@@ -44,7 +44,7 @@ resource "aws_s3_bucket" "pulsar_offload" {
     }
   }
 
-  tags   = merge({ "Attributes" = "offload", "Name" = "offload" }, var.tags)
+  tags = merge({ "Attributes" = "offload", "Name" = "offload" }, var.tags)
 }
 
 data "aws_iam_policy_document" "tiered_storage_base_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "add_vpc_tags" {
   type        = bool
 }
 
+variable "asm_secret_arns" {
+  default     = []
+  description = "The a list of ARNs for secrets stored in ASM. This grants the kubernetes-external-secrets controller select access to secrets used by resources within the EKS cluster. If no arns are provided via this input, the IAM policy will allow read access to all secrets created in the provided region"
+  type        = list(string)
+}
+
 variable "aws_load_balancer_controller_helm_chart_name" {
   default     = "aws-load-balancer-controller"
   description = "The name of the Helm chart to use for the AWS Load Balancer Controller."
@@ -189,6 +195,12 @@ variable "enable_csi" {
   type        = bool
 }
 
+variable "enable_external_secrets" {
+  default     = true
+  description = "Enables kubernetes-external-secrets on the cluster, which uses AWS Secrets Manager as the secrets backend"
+  type        = bool
+}
+
 variable "enable_func_pool" {
   default     = false
   description = "Enable an additional dedicated function pool"
@@ -216,6 +228,30 @@ variable "external_dns_helm_chart_version" {
 variable "external_dns_settings" {
   default     = {}
   description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/bitnami/external-dns"
+  type        = map(any)
+}
+
+variable "external_secrets_helm_chart_name" {
+  default     = "kubernetes-external-secrets"
+  description = "The name of the Helm chart in the repository for kubernetes-external-secrets"
+  type        = string
+}
+
+variable "external_secrets_helm_chart_repository" {
+  default     = "https://external-secrets.github.io/kubernetes-external-secrets"
+  description = "The repository containing the kubernetes-external-secrets helm chart"
+  type        = string
+}
+
+variable "external_secrets_helm_chart_version" {
+  default     = "8.3.0"
+  description = "Helm chart version for kubernetes-external-secrets. Defaults to \"8.3.0\". See https://github.com/external-secrets/kubernetes-external-secrets/tree/master/charts/kubernetes-external-secrets for updates"
+  type        = string
+}
+
+variable "external_secrets_settings" {
+  default     = {}
+  description = "Additional settings which will be passed to the Helm chart values, see https://github.com/external-secrets/kubernetes-external-secrets/tree/master/charts/kubernetes-external-secrets for available options"
   type        = map(any)
 }
 


### PR DESCRIPTION
This PR brings `kubernetes-external-secrets` into the module, which is enabled by default. Refer to the README for example usage.