### PR TITLE
[addons] Install addons in kube-system

### DIFF
--- a/aws_load_balancer_controller.tf
+++ b/aws_load_balancer_controller.tf
@@ -253,7 +253,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller_sts" {
     }
     condition {
       test     = "StringLike"
-      values   = [format("system:serviceaccount:%s:%s", kubernetes_namespace.sn_system.id, "aws-load-balancer-controller")]
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "aws-load-balancer-controller")]
       variable = format("%s:sub", local.oidc_issuer)
     }
   }
@@ -290,7 +290,7 @@ resource "helm_release" "aws_load_balancer_controller" {
   chart           = var.aws_load_balancer_controller_helm_chart_name
   cleanup_on_fail = true
   name            = "aws-load-balancer-controller"
-  namespace       = kubernetes_namespace.sn_system.id
+  namespace       = "kube-system"
   repository      = var.aws_load_balancer_controller_helm_chart_repository
   timeout         = 300
   version         = var.aws_load_balancer_controller_helm_chart_version

--- a/aws_node_termination_handler.tf
+++ b/aws_node_termination_handler.tf
@@ -23,7 +23,7 @@ resource "helm_release" "node_termination_handler" {
   chart           = var.node_termination_handler_helm_chart_name
   cleanup_on_fail = true
   name            = "node-termination-handler"
-  namespace       = kubernetes_namespace.sn_system.id
+  namespace       = "kube-system"
   repository      = var.node_termination_handler_helm_chart_repository
   timeout         = 300
 

--- a/calico.tf
+++ b/calico.tf
@@ -23,7 +23,7 @@ resource "helm_release" "calico" {
   chart           = var.calico_helm_chart_name
   cleanup_on_fail = true
   name            = "tigera-operator"
-  namespace       = kubernetes_namespace.sn_system.id
+  namespace       = "kube-system"
   repository      = var.calico_helm_chart_repository
   timeout         = 300
   version         = var.calico_helm_chart_version

--- a/cert_manager.tf
+++ b/cert_manager.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "cert_manager_sts" {
     }
     condition {
       test     = "StringLike"
-      values   = [format("system:serviceaccount:%s:%s", kubernetes_namespace.sn_system.id, "cert-manager")]
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "cert-manager")]
       variable = format("%s:sub", local.oidc_issuer)
     }
   }
@@ -102,7 +102,7 @@ resource "helm_release" "cert_manager" {
   chart           = var.cert_manager_helm_chart_name
   cleanup_on_fail = true
   name            = "cert-manager"
-  namespace       = kubernetes_namespace.sn_system.id
+  namespace       = "kube-system"
   repository      = var.cert_manager_helm_chart_repository
   timeout         = 300
   version         = var.cert_manager_helm_chart_version

--- a/cluster_autoscaler.tf
+++ b/cluster_autoscaler.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_sts" {
     }
     condition {
       test     = "StringLike"
-      values   = [format("system:serviceaccount:%s:%s", kubernetes_namespace.sn_system.id, "cluster-autoscaler")]
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "cluster-autoscaler")]
       variable = format("%s:sub", local.oidc_issuer)
     }
   }
@@ -100,7 +100,7 @@ resource "helm_release" "cluster_autoscaler" {
   chart           = var.cluster_autoscaler_helm_chart_name
   cleanup_on_fail = true
   name            = "cluster-autoscaler"
-  namespace       = kubernetes_namespace.sn_system.id
+  namespace       = "kube-system"
   repository      = var.cluster_autoscaler_helm_chart_repository
   timeout         = 300
   version         = var.cluster_autoscaler_helm_chart_version

--- a/csi.tf
+++ b/csi.tf
@@ -133,7 +133,7 @@ data "aws_iam_policy_document" "csi_sts" {
     }
     condition {
       test     = "StringEquals"
-      values   = [format("system:serviceaccount:%s:%s", kubernetes_namespace.sn_system.id, "ebs-csi-controller-sa")]
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "ebs-csi-controller-sa")]
       variable = format("%s:sub", local.oidc_issuer)
     }
     condition {
@@ -175,7 +175,7 @@ resource "helm_release" "csi" {
   chart           = var.csi_helm_chart_name
   cleanup_on_fail = true
   name            = "aws-ebs-csi-driver"
-  namespace       = kubernetes_namespace.sn_system.id
+  namespace       = "kube-system"
   repository      = var.csi_helm_chart_repository
   timeout         = 300
 

--- a/external_dns.tf
+++ b/external_dns.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "external_dns_sts" {
     }
     condition {
       test     = "StringLike"
-      values   = [format("system:serviceaccount:%s:%s", kubernetes_namespace.sn_system.id, "external-dns")]
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "external-dns")]
       variable = format("%s:sub", local.oidc_issuer)
     }
   }
@@ -91,7 +91,7 @@ resource "helm_release" "external_dns" {
   atomic          = true
   chart           = var.external_dns_helm_chart_name
   cleanup_on_fail = true
-  namespace       = kubernetes_namespace.sn_system.id
+  namespace       = "kube-system"
   name            = "external-dns"
   repository      = var.external_dns_helm_chart_repository
   timeout         = 300

--- a/external_secrets.tf
+++ b/external_secrets.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "external_secrets_sts" {
     }
     condition {
       test     = "StringLike"
-      values   = [format("system:serviceaccount:%s:%s", kubernetes_namespace.sn_system.id, "external-secrets")]
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "external-secrets")]
       variable = format("%s:sub", local.oidc_issuer)
     }
   }
@@ -87,7 +87,7 @@ resource "helm_release" "external_secrets" {
   atomic          = true
   chart           = var.external_secrets_helm_chart_name
   cleanup_on_fail = true
-  namespace       = kubernetes_namespace.sn_system.id
+  namespace       = "kube-system"
   name            = "external-secrets"
   repository      = var.external_secrets_helm_chart_repository
   timeout         = 300


### PR DESCRIPTION
The ongoing work of bringing Istio support to this module has highligted the need for installing cluster specific addons into the `kube-system` namespace instead of `sn-system`.  This PR addresses this by changing the namespace for the Helm deployments accordingly.

In the future, `sn-system` will be reserved for StreamNative components, such as our operators and Istio itself.