### PR TITLE
[addons] Changed addon helm config format to native HCL data object

### DIFF
--- a/aws_load_balancer_controller.tf
+++ b/aws_load_balancer_controller.tf
@@ -294,33 +294,19 @@ resource "helm_release" "aws_load_balancer_controller" {
   repository      = var.aws_load_balancer_controller_helm_chart_repository
   timeout         = 300
   version         = var.aws_load_balancer_controller_helm_chart_version
-
-  set {
-    name  = "clusterName"
-    value = module.eks.cluster_id
-    type  = "string"
-  }
-
-  # set {
-  #   name  = "defaultTags"
-  #   value = jsonencode({ Vendor = "StreamNative" }) #TODO - figure out how to pass multiple KV pairs
-  # }
-
-  set {
-    name  = "serviceAccount.create"
-    value = "true"
-  }
-
-  set {
-    name  = "serviceAccount.name"
-    value = "aws-load-balancer-controller"
-  }
-
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com\\/role\\-arn"
-    value = aws_iam_role.aws_load_balancer_controller[0].arn
-    type  = "string"
-  }
+  values = [yamlencode({
+    clusterName = module.eks.cluster_id
+    defaultTags = merge(var.additional_tags, {
+      "Vendor" = "StreamNative"
+    })
+    serviceAccount = {
+      create = true
+      name   = "aws-load-balancer-controller"
+      annotations = {
+        "eks.amazonaws.com/role-arn" = aws_iam_role.aws_load_balancer_controller[0].arn
+      }
+    }
+  })]
 
   dynamic "set" {
     for_each = var.aws_load_balancer_controller_settings

--- a/aws_load_balancer_controller.tf
+++ b/aws_load_balancer_controller.tf
@@ -296,9 +296,9 @@ resource "helm_release" "aws_load_balancer_controller" {
   version         = var.aws_load_balancer_controller_helm_chart_version
   values = [yamlencode({
     clusterName = module.eks.cluster_id
-    defaultTags = merge(var.additional_tags, {
-      "Vendor" = "StreamNative"
-    })
+    # defaultTags = merge(var.additional_tags, {
+    #   "Vendor" = "StreamNative"
+    # })
     serviceAccount = {
       create = true
       name   = "aws-load-balancer-controller"

--- a/aws_node_termination_handler.tf
+++ b/aws_node_termination_handler.tf
@@ -26,6 +26,7 @@ resource "helm_release" "node_termination_handler" {
   namespace       = "kube-system"
   repository      = var.node_termination_handler_helm_chart_repository
   timeout         = 300
+  version         = var.node_termination_handler_chart_version
 
   dynamic "set" {
     for_each = var.node_termination_handler_settings

--- a/calico.tf
+++ b/calico.tf
@@ -27,12 +27,17 @@ resource "helm_release" "calico" {
   repository      = var.calico_helm_chart_repository
   timeout         = 300
   version         = var.calico_helm_chart_version
-
-  set {
-    name  = "installation.kubernetesProvider"
-    value = "EKS"
-    type  = "string"
-  }
+  values = [yamlencode({
+    installation = {
+      kubernetesProvider = "EKS"
+      enabled = true 
+      spec = { 
+        cni = {
+          type = "AmazonVPC"
+        }
+      }
+    }
+  })]
 
   dynamic "set" {
     for_each = var.calico_settings

--- a/calico.tf
+++ b/calico.tf
@@ -30,8 +30,8 @@ resource "helm_release" "calico" {
   values = [yamlencode({
     installation = {
       kubernetesProvider = "EKS"
-      enabled = true 
-      spec = { 
+      enabled            = true
+      spec = {
         cni = {
           type = "AmazonVPC"
         }

--- a/cert_manager.tf
+++ b/cert_manager.tf
@@ -106,32 +106,44 @@ resource "helm_release" "cert_manager" {
   repository      = var.cert_manager_helm_chart_repository
   timeout         = 300
   version         = var.cert_manager_helm_chart_version
+  values = [yamlencode({
+    installCRDs = true
+    controller = {
+      args = [
+        "--issuer-ambient-credentials=true"
+      ]
+    }
+    kubeVersion = var.cluster_version
+    podSecurityContext = {
+      fsGroup = 65534
+    }
+    serviceaccount = {
+      annotations = {
+        "eks.amazonaws.com/role-arn" = aws_iam_role.cert_manager[0].arn
+      }
+    }
+  })]
 
-  set {
-    name  = "installCRDs"
-    value = true
-  }
+  # set {
+  #   name  = "installCRDs"
+  #   value = true
+  # }
 
-  set {
-    name  = "serviceAccount.name"
-    value = "cert-manager"
-  }
+  # set {
+  #   name  = "extraArgs[0]"
+  #   value = "--issuer-ambient-credentials=true"
+  # }
 
-  set {
-    name  = "extraArgs[0]"
-    value = "--issuer-ambient-credentials=true"
-  }
+  # set {
+  #   name  = "securityContext.fsGroup"
+  #   value = "65534"
+  # }
 
-  set {
-    name  = "securityContext.fsGroup"
-    value = "65534"
-  }
-
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com\\/role\\-arn"
-    value = aws_iam_role.cert_manager[0].arn
-    type  = "string"
-  }
+  # set {
+  #   name  = "serviceAccount.annotations.eks\\.amazonaws\\.com\\/role\\-arn"
+  #   value = aws_iam_role.cert_manager[0].arn
+  #   type  = "string"
+  # }
 
   dynamic "set" {
     for_each = var.cert_manager_settings

--- a/cluster_autoscaler.tf
+++ b/cluster_autoscaler.tf
@@ -94,8 +94,13 @@ resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
   role       = aws_iam_role.cluster_autoscaler[0].name
 }
 
-# Keep this issue in mind when running autoscaler, especially if you are seeing OOMKilled errors.
+############
+# Keep this issue in mind when running CA on AWS/EKS, especially if you are seeing OOMKilled errors on the CA pod.
 # https://github.com/kubernetes/autoscaler/issues/3506
+#
+# Also Refer to the CA FAQ for troubleshooting or configuration options
+# https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-the-parameters-to-ca
+############
 resource "helm_release" "cluster_autoscaler" {
   count           = var.enable_cluster_autoscaler ? 1 : 0
   atomic          = true
@@ -104,7 +109,7 @@ resource "helm_release" "cluster_autoscaler" {
   name            = "cluster-autoscaler"
   namespace       = "kube-system"
   repository      = var.cluster_autoscaler_helm_chart_repository
-  timeout         = 300
+  timeout         = 120
   version         = var.cluster_autoscaler_helm_chart_version
   values = [yamlencode({
     autoDiscovery = {
@@ -114,7 +119,7 @@ resource "helm_release" "cluster_autoscaler" {
     cloudProvider = "aws"
     extraArgs = {
       balance-similar-node-groups   = true
-      expander                      = "least-waste"
+      expander                      = "random"
       node-group-auto-discovery     = format("asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/%s", module.eks.cluster_id)
       skip-nodes-with-system-pods   = false
       skip-nodes-with-local-storage = false
@@ -134,6 +139,9 @@ resource "helm_release" "cluster_autoscaler" {
         readOnly  = true
       }
     ]
+    image = {
+      tag = lookup(local.k8s_to_autoscaler_version, var.cluster_version, "v1.20.1") # image.tag defaults to the version corresponding to var.cluster_version's default value and must manually be updated
+    }
     rbac = {
       create     = true
       pspEnabled = true
@@ -149,7 +157,7 @@ resource "helm_release" "cluster_autoscaler" {
     replicaCount = "1"
     resources = {
       limits = {
-        cpu    = "100m"
+        cpu    = "200m"
         memory = "1Gi"
       },
       requests = {

--- a/cluster_autoscaler.tf
+++ b/cluster_autoscaler.tf
@@ -94,6 +94,8 @@ resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
   role       = aws_iam_role.cluster_autoscaler[0].name
 }
 
+# Keep this issue in mind when running autoscaler, especially if you are seeing OOMKilled errors.
+# https://github.com/kubernetes/autoscaler/issues/3506
 resource "helm_release" "cluster_autoscaler" {
   count           = var.enable_cluster_autoscaler ? 1 : 0
   atomic          = true
@@ -104,6 +106,59 @@ resource "helm_release" "cluster_autoscaler" {
   repository      = var.cluster_autoscaler_helm_chart_repository
   timeout         = 300
   version         = var.cluster_autoscaler_helm_chart_version
+  values = [yamlencode({
+    autoDiscovery = {
+      clusterName = module.eks.cluster_id
+    }
+    awsRegion     = var.region
+    cloudProvider = "aws"
+    extraArgs = {
+      balance-similar-node-groups   = true
+      expander                      = "least-waste"
+      node-group-auto-discovery     = format("asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/%s", module.eks.cluster_id)
+      skip-nodes-with-system-pods   = false
+      skip-nodes-with-local-storage = false
+    }
+    extraVolumes = [
+      {
+        name = "ssl-certs"
+        hostPath = {
+          path = "/etc/ssl/certs/ca-bundle.crt"
+        }
+      }
+    ]
+    extraVolumeMounts = [
+      {
+        name      = "ssl-certs"
+        mountPath = "/etc/ssl/certs/ca-certificates.crt"
+        readOnly  = true
+      }
+    ]
+    rbac = {
+      create     = true
+      pspEnabled = true
+      serviceAccount = {
+        annotations = {
+          "eks.amazonaws.com/role-arn" = aws_iam_role.cluster_autoscaler[0].arn
+        },
+        create                       = true
+        name                         = "cluster-autoscaler"
+        automountServiceAccountToken = true
+      }
+    }
+    replicaCount = "1"
+    resources = {
+      limits = {
+        cpu    = "100m"
+        memory = "1Gi"
+      },
+      requests = {
+        cpu    = "100m"
+        memory = "500Mi"
+      }
+    }
+    })
+  ]
 
   dynamic "set" {
     for_each = var.cluster_autoscaler_settings
@@ -112,61 +167,4 @@ resource "helm_release" "cluster_autoscaler" {
       value = set.value
     }
   }
-
-  # Keep this issue in mind when running autoscaler, especially if you are seeing OOMKilled errors.
-  # https://github.com/kubernetes/autoscaler/issues/3506
-  values = [
-    yamlencode({
-      "autoDiscovery" : {
-        "clusterName" : "${module.eks.cluster_id}",
-      }
-      "awsRegion" : "${var.region}"
-      "cloudProvider" : "aws"
-      "extraArgs" : {
-        "balance-similar-node-groups" : true,
-        "expander" : "least-waste",
-        "node-group-auto-discovery" : "asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-autoscaler/${module.eks.cluster_id}"
-        "skip-nodes-with-system-pods" : false,
-        "skip-nodes-with-local-storage" : false,
-      }
-      "extraVolumes" : [
-        {
-          "name" : "ssl-certs",
-          "hostPath" : {
-            "path" : "/etc/ssl/certs/ca-bundle.crt"
-          }
-        }
-      ]
-      "extraVolumeMounts" : [
-        {
-          "name" : "ssl-certs",
-          "mountPath" : "/etc/ssl/certs/ca-certificates.crt",
-          "readOnly" : true
-        }
-      ]
-      "rbac" : {
-        "create" : true,
-        "pspEnabled" : true,
-        "serviceAccount" : {
-          "annotations" : {
-            "eks.amazonaws.com/role-arn" : "${aws_iam_role.cluster_autoscaler[0].arn}"
-          },
-          "create" : true,
-          "name" : "cluster-autoscaler",
-          "automountServiceAccountToken" : true
-        }
-      }
-      "replicaCount" : "1"
-      "resources" : {
-        "limits" : {
-          "cpu" : "100m",
-          "memory" : "500Mi"
-        },
-        "requests" : {
-          "cpu" : "100m",
-          "memory" : "500Mi"
-        }
-      }
-    })
-  ]
 }

--- a/external_dns.tf
+++ b/external_dns.tf
@@ -96,55 +96,27 @@ resource "helm_release" "external_dns" {
   repository      = var.external_dns_helm_chart_repository
   timeout         = 300
   version         = var.external_dns_helm_chart_version
-
-  set {
-    name  = "aws.region"
-    value = var.region
-  }
-
-  set {
-    name  = "podSecurityContext.fsGroup"
-    value = "65534"
-  }
-
-  set {
-    name  = "podSecurityContext.runAsUser"
-    value = "0"
-  }
-
-  set {
-    name  = "rbac.create"
-    value = "true"
-    type  = "string"
-  }
-
-  set {
-    name  = "serviceAccount.create"
-    value = "true"
-    type  = "string"
-  }
-
-  set {
-    name  = "serviceAccount.name"
-    value = "external-dns"
-    type  = "string"
-  }
-
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com\\/role\\-arn"
-    value = aws_iam_role.external_dns[0].arn
-    type  = "string"
-  }
-
-  set {
-    name  = "sources"
-    value = var.enable_istio_operator == true ? "{service,ingress,istio-gateway,istio-virtualservice}" : "{service,ingress}"
-  }
-
-  set {
-    name  = "txtOwnerId"
-    value = module.eks.cluster_id
-  }
+  values = [yamlencode({
+    aws = {
+      region = var.region
+    }
+    podSecurityContext = {
+      fsGroup   = 65534
+      runAsUser = 0
+    }
+    rbac = {
+      create = true
+    }
+    serviceAccount = {
+      create = true
+      name   = "external-dns"
+      annotations = {
+        "eks.amazonaws.com/role-arn" = aws_iam_role.external_dns[0].arn
+      }
+    }
+    sources    = local.sources
+    txtOwnerId = module.eks.cluster_id
+  })]
 
   dynamic "set" {
     for_each = var.external_dns_settings

--- a/external_secrets.tf
+++ b/external_secrets.tf
@@ -92,27 +92,20 @@ resource "helm_release" "external_secrets" {
   repository      = var.external_secrets_helm_chart_repository
   timeout         = 300
   version         = var.external_secrets_helm_chart_version
-
-  set {
-    name  = "env.AWS_REGION"
-    value = var.region
-  }
-
-  set {
-    name  = "securityContext.fsGroup"
-    value = "65534"
-  }
-
-  set {
-    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com\\/role\\-arn"
-    value = aws_iam_role.external_secrets[0].arn
-    type  = "string"
-  }
-
-  set {
-    name  = "serviceAccount.name"
-    value = "external-secrets"
-  }
+  values = [yamlencode({
+    env = {
+      AWS_REGION = var.region
+    }
+    securityContext = {
+      fsGroup = 65534
+    }
+    serviceAccount = {
+      annotations = {
+        "eks.amazonaws.com/role-arn" = aws_iam_role.external_secrets[0].arn
+      }
+      name = "external-secrets"
+    }
+  })]
 
   dynamic "set" {
     for_each = var.external_secrets_settings

--- a/locals.tf
+++ b/locals.tf
@@ -24,6 +24,14 @@ locals {
   cluster_subnet_ids = concat(var.private_subnet_ids, var.public_subnet_ids)
   oidc_issuer        = trimprefix(module.eks.cluster_oidc_issuer_url, "https://")
 
+  k8s_to_autoscaler_version = {
+    "1.18" = "v1.18.3",
+    "1.19" = "v1.19.2",
+    "1.20" = "v1.20.1",
+    "1.21" = "v1.21.1",
+    "1.22" = "v1.22.1",
+  }
+
   ### Istio Config
   default_sources          = ["service", "ingress"]
   istio_namespace          = var.istio_namespace == "istio-system" ? "istio-system" : var.istio_namespace

--- a/locals.tf
+++ b/locals.tf
@@ -20,11 +20,16 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  account_id               = data.aws_caller_identity.current.account_id
-  cluster_subnet_ids       = concat(var.private_subnet_ids, var.public_subnet_ids)
+  account_id         = data.aws_caller_identity.current.account_id
+  cluster_subnet_ids = concat(var.private_subnet_ids, var.public_subnet_ids)
+  oidc_issuer        = trimprefix(module.eks.cluster_oidc_issuer_url, "https://")
+
+  ### Istio Config
+  default_sources          = ["service", "ingress"]
   istio_namespace          = var.istio_namespace == "istio-system" ? "istio-system" : var.istio_namespace
   istio_operator_namespace = var.istio_operator_namespace == "istio-operator" ? "istio-operator" : var.istio_operator_namespace
-  oidc_issuer              = trimprefix(module.eks.cluster_oidc_issuer_url, "https://")
+  istio_sources            = ["istio-gateway", "istio-virtualservice"]
+  sources                  = var.enable_istio_operator ? concat(local.istio_sources, local.default_sources) : local.default_sources
 
   ### Node Groups
   func_pool_defaults = {

--- a/variables.tf
+++ b/variables.tf
@@ -78,7 +78,7 @@ variable "calico_helm_chart_repository" {
 }
 
 variable "calico_helm_chart_version" {
-  default     = "1.0.5"
+  default     = "1.5.0"
   description = "Helm chart version for Calico. Defaults to \"1.0.5\". See https://github.com/stevehipwell/helm-charts/tree/master/charts/tigera-operator for available version releases."
   type        = string
 }
@@ -96,14 +96,14 @@ variable "cert_manager_helm_chart_name" {
 }
 
 variable "cert_manager_helm_chart_repository" {
-  default     = "https://charts.jetstack.io"
+  default     = "https://charts.bitnami.com/bitnami"
   description = "The repository containing the cert-manager helm chart."
   type        = string
 }
 
 variable "cert_manager_helm_chart_version" {
-  default     = "1.4.0"
-  description = "Helm chart version for the cert-manager. Defaults to \"1.4.0\". See https://github.com/bitnami/charts/tree/master/bitnami/cert-manager for version releases."
+  default     = "0.1.27"
+  description = "Helm chart version for the cert-manager. See https://github.com/bitnami/charts/tree/master/bitnami/cert-manager for version releases."
   type        = string
 }
 
@@ -126,7 +126,7 @@ variable "cluster_autoscaler_helm_chart_repository" {
 }
 
 variable "cluster_autoscaler_helm_chart_version" {
-  default     = "9.10.4"
+  default     = "9.10.8"
   description = "Helm chart version for the cluster-autoscaler. Defaults to \"9.10.4\". See https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler for more details."
   type        = string
 }
@@ -167,7 +167,7 @@ variable "cluster_name" {
 }
 
 variable "cluster_version" {
-  default     = "1.18"
+  default     = "1.20"
   description = "The version of Kubernetes to be installed."
   type        = string
 }
@@ -181,6 +181,12 @@ variable "csi_helm_chart_name" {
 variable "csi_helm_chart_repository" {
   default     = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver/"
   description = "The repository containing the CSI helm chart"
+  type        = string
+}
+
+variable "csi_helm_chart_version" {
+  default     = "2.4.1"
+  description = "Helm chart version for CSI"
   type        = string
 }
 
@@ -268,7 +274,7 @@ variable "external_dns_helm_chart_repository" {
 }
 
 variable "external_dns_helm_chart_version" {
-  default     = "5.4.1"
+  default     = "5.5.2"
   description = "Helm chart version for ExternalDNS. Defaults to \"4.9.0\". See https://hub.helm.sh/charts/bitnami/external-dns for updates."
   type        = string
 }
@@ -500,6 +506,12 @@ variable "node_termination_handler_settings" {
   default     = {}
   description = "Additional settings which will be passed to the Helm chart values for the AWS Node Termination Handler. See https://github.com/kubernetes-sigs/aws-load-balancer-controller/tree/main/helm/aws-load-balancer-controller for available options."
   type        = map(string)
+}
+
+variable "node_termination_handler_chart_version" {
+  default     = "0.16.0"
+  description = "The version of the Helm chart to use for the AWS Node Termination Handler."
+  type        = string
 }
 
 variable "node_pool_desired_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -209,8 +209,8 @@ variable "enable_aws_node_termination_handler" {
 }
 
 variable "enable_calico" {
-  default     = true
-  description = "Enables the Calico networking service on the cluster. Defaults to \"true\", and in most situations is required by StreamNative Cloud."
+  default     = false
+  description = "Enables the Calico networking service on the cluster. Defaults to \"false\"."
   type        = bool
 }
 


### PR DESCRIPTION
This is a mostly cosmetic change where we're standardizing on how we pass values to `helm_release`. Other changes are detailed below.

Previously this was done through a number of `set {}` value blocks, which is pretty rigid in terms of data types (lists, for instance, require some ugly hacks in HCL).

The better approach that we've found is to define a complex type,  and pass that to the `values = []` input with `yamlencode()`.  We'll continue this pattern in other modules and make it the standard going forward.

### Other changes in this PR include:

- Updated default Kubernetes version for EKS from 1.18 to 1.20
- Chart version defaults for minor updates
- Creates a Calico CR when the Tigera operator is enabled and installed