### PR TITLE
Fix storageclass encryption config.

### DIFF
--- a/csi.tf
+++ b/csi.tf
@@ -247,7 +247,7 @@ resource "kubernetes_storage_class" "sn_default" {
   storage_provisioner = var.enable_csi ? "ebs.csi.aws.com" : "kubernetes.io/aws-ebs"
   parameters = {
     type       = "gp3"
-    encryption = "true"
+    encrypted = "true"
     kmsKeyId   = local.kms_key
   }
   reclaim_policy         = "Delete"
@@ -262,7 +262,7 @@ resource "kubernetes_storage_class" "sn_ssd" {
   storage_provisioner = var.enable_csi ? "ebs.csi.aws.com" : "kubernetes.io/aws-ebs"
   parameters = {
     type       = "gp3"
-    encryption = "true"
+    encrypted = "true"
     kmsKeyId   = local.kms_key
   }
   reclaim_policy         = "Delete"


### PR DESCRIPTION
In newly create AWS poolmember, PVC stuck in pending status with events:
```
Events:
  Type     Reason                Age                    From                                                                                      Message
  ----     ------                ----                   ----                                                                                      -------
  Normal   WaitForFirstConsumer  43m                    persistentvolume-controller                                                               waiting for first consumer to be created before binding
  Warning  ProvisioningFailed    14m (x15 over 43m)     ebs.csi.aws.com_ebs-csi-controller-86d995b7c7-hw9h8_6dfba1d0-c1a4-4576-af9d-debab8944b08  failed to provision volume with StorageClass "sn-default": rpc error: code = InvalidArgument desc = Invalid parameter key encryption for CreateVolume
```

Seems it should be `encrypted` not `encryption`:  https://kubernetes.io/docs/concepts/storage/storage-classes/#aws-ebs