### PR TITLE
Fixes for cluster addons

### DIFF
--- a/aws_load_balancer_controller.tf
+++ b/aws_load_balancer_controller.tf
@@ -261,7 +261,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller_sts" {
 
 resource "aws_iam_role" "aws_load_balancer_controller" {
   count                = var.enable_aws_load_balancer_controller ? 1 : 0
-  name                 = format("%s-aws-load-balancer-controller-role", module.eks.cluster_id)
+  name                 = format("%s-lbc-role", module.eks.cluster_id)
   description          = format("Role used by IRSA and the KSA aws-load-balancer-controller on StreamNative Cloud EKS cluster %s", module.eks.cluster_id)
   assume_role_policy   = data.aws_iam_policy_document.aws_load_balancer_controller_sts.json
   path                 = "/StreamNative/"

--- a/cert_manager.tf
+++ b/cert_manager.tf
@@ -117,7 +117,8 @@ resource "helm_release" "cert_manager" {
     podSecurityContext = {
       fsGroup = 65534
     }
-    serviceaccount = {
+    serviceAccount = {
+      name = "cert-manager"
       annotations = {
         "eks.amazonaws.com/role-arn" = aws_iam_role.cert_manager[0].arn
       }

--- a/cert_manager.tf
+++ b/cert_manager.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "cert_manager_sts" {
     }
     condition {
       test     = "StringLike"
-      values   = [format("system:serviceaccount:%s:%s", "kube-system", "cert-manager")]
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "cert-manager-controller")]
       variable = format("%s:sub", local.oidc_issuer)
     }
   }
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "cert_manager_sts" {
 
 resource "aws_iam_role" "cert_manager" {
   count                = var.enable_cert_manager ? 1 : 0
-  name                 = format("%s-cert-manager-role", module.eks.cluster_id)
+  name                 = format("%s-cm-role", module.eks.cluster_id)
   description          = format("Role assumed by IRSA and the KSA cert-manager on StreamNative Cloud EKS cluster %s", module.eks.cluster_id)
   assume_role_policy   = data.aws_iam_policy_document.cert_manager_sts.json
   path                 = "/StreamNative/"
@@ -112,17 +112,17 @@ resource "helm_release" "cert_manager" {
       args = [
         "--issuer-ambient-credentials=true"
       ]
-    }
-    kubeVersion = var.cluster_version
-    podSecurityContext = {
-      fsGroup = 65534
-    }
-    serviceAccount = {
-      name = "cert-manager"
-      annotations = {
-        "eks.amazonaws.com/role-arn" = aws_iam_role.cert_manager[0].arn
+      serviceAccount = {
+        annotations = {
+          "eks.amazonaws.com/role-arn" = aws_iam_role.cert_manager[0].arn
+        }
+      }
+      podSecurityContext = {
+        fsGroup = 65534
       }
     }
+    kubeVersion = var.cluster_version
+
   })]
 
   dynamic "set" {

--- a/cluster_autoscaler.tf
+++ b/cluster_autoscaler.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_sts" {
 
 resource "aws_iam_role" "cluster_autoscaler" {
   count                = var.enable_cluster_autoscaler ? 1 : 0
-  name                 = format("%s-cluster-autoscaler-role", module.eks.cluster_id)
+  name                 = format("%s-ca-role", module.eks.cluster_id)
   description          = format("Role used by IRSA and the KSA cluster-autoscaler on StreamNative Cloud EKS cluster %s", module.eks.cluster_id)
   assume_role_policy   = data.aws_iam_policy_document.cluster_autoscaler_sts.json
   path                 = "/StreamNative/"

--- a/csi.tf
+++ b/csi.tf
@@ -246,9 +246,9 @@ resource "kubernetes_storage_class" "sn_default" {
   }
   storage_provisioner = var.enable_csi ? "ebs.csi.aws.com" : "kubernetes.io/aws-ebs"
   parameters = {
-    type       = "gp3"
+    type      = "gp3"
     encrypted = "true"
-    kmsKeyId   = local.kms_key
+    kmsKeyId  = local.kms_key
   }
   reclaim_policy         = "Delete"
   allow_volume_expansion = true
@@ -261,9 +261,9 @@ resource "kubernetes_storage_class" "sn_ssd" {
   }
   storage_provisioner = var.enable_csi ? "ebs.csi.aws.com" : "kubernetes.io/aws-ebs"
   parameters = {
-    type       = "gp3"
+    type      = "gp3"
     encrypted = "true"
-    kmsKeyId   = local.kms_key
+    kmsKeyId  = local.kms_key
   }
   reclaim_policy         = "Delete"
   allow_volume_expansion = true

--- a/external_dns.tf
+++ b/external_dns.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "external_dns_sts" {
 
 resource "aws_iam_role" "external_dns" {
   count                = var.enable_external_dns ? 1 : 0
-  name                 = format("%s-external-dns-role", module.eks.cluster_id)
+  name                 = format("%s-extdns-role", module.eks.cluster_id)
   description          = format("Role used by IRSA and the KSA external-dns on StreamNative Cloud EKS cluster %s", module.eks.cluster_id)
   assume_role_policy   = data.aws_iam_policy_document.external_dns_sts.json
   path                 = "/StreamNative/"

--- a/external_secrets.tf
+++ b/external_secrets.tf
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "external_secrets_sts" {
 
 resource "aws_iam_role" "external_secrets" {
   count                = var.enable_external_secrets ? 1 : 0
-  name                 = format("%s-external-secrets-role", module.eks.cluster_id)
+  name                 = format("%s-extsec-role", module.eks.cluster_id)
   description          = format("Role used by IRSA and the KSA external-secrets on StreamNative Cloud EKS cluster %s", module.eks.cluster_id)
   assume_role_policy   = data.aws_iam_policy_document.external_secrets_sts.json
   path                 = "/StreamNative/"


### PR DESCRIPTION
This PR addresses [issue](https://github.com/streamnative/terraform-aws-cloud/issues/43), where IAM role resource names were bumping into character limit constraints. 

It also addresses a misconfiguration in the helm values for the `cert-manager` addon.