### PR TITLE
Add missing permission to management policy needed by control plane

### DIFF
--- a/modules/managed-cloud/cloudformation/managed_cloud.yaml
+++ b/modules/managed-cloud/cloudformation/managed_cloud.yaml
@@ -649,7 +649,7 @@ Resources:
                       "Effect": "Allow",
                       "Action": [
                         "acm:AddTagsToCertificate",
-                        "acm:ImportCertificate",
+                        "acm:ImportCertificate"
                       ],
                       "Resource": [
                         "*"

--- a/modules/managed-cloud/cloudformation/managed_cloud.yaml
+++ b/modules/managed-cloud/cloudformation/managed_cloud.yaml
@@ -543,6 +543,7 @@ Resources:
                       "Sid": "AllowedServices",
                       "Effect": "Allow",
                       "Action": [
+                        "acm:List*",
                         "cloudwatch:Describe*",
                         "cloudwatch:List*",
                         "cloudwatch:Get*",
@@ -612,9 +613,12 @@ Resources:
                 		  }
                 		},
                     {
-                      "Sid": "RestrictedActions",
+                      "Sid": "RequireResourceTag",
                       "Effect": "Allow",
                       "Action": [
+                        "acm:DeleteCertificate",
+                        "acm:DescribeCertificate",
+                        "acm:GetCertificate",
                         "autoscaling:CancelInstanceRefresh",
                         "autoscaling:Describe*",
                         "autoscaling:PutScalingPolicy",
@@ -639,6 +643,22 @@ Resources:
                           "aws:ResourceTag/Vendor": "StreamNative"
                         }
                       }
+                    },
+                    {
+                      "Sid": "RequireRequestTag",
+                      "Effect": "Allow",
+                      "Action": [
+                        "acm:AddTagsToCertificate",
+                        "acm:ImportCertificate",
+                      ],
+                      "Resource": [
+                        "*"
+                      ],
+                      "Condition": {
+                        "StringEqualsIgnoreCase": {
+                           "aws:RequestTag/Vendor": "StreamNative"
+                       }
+                     }
                     }
                   ]
                 }

--- a/modules/managed-cloud/files/management_role_iam_policy.json.tpl
+++ b/modules/managed-cloud/files/management_role_iam_policy.json.tpl
@@ -111,7 +111,7 @@
       "Effect": "Allow",
       "Action": [
         "acm:AddTagsToCertificate",
-        "acm:ImportCertificate",
+        "acm:ImportCertificate"
       ],
       "Resource": [
         "*"

--- a/modules/managed-cloud/files/management_role_iam_policy.json.tpl
+++ b/modules/managed-cloud/files/management_role_iam_policy.json.tpl
@@ -5,6 +5,7 @@
       "Sid": "AllowedServices",
       "Effect": "Allow",
       "Action": [
+        "acm:List*",
         "cloudwatch:Describe*",
         "cloudwatch:List*",
         "cloudwatch:Get*",
@@ -74,9 +75,12 @@
 			}
 		},
     {
-      "Sid": "RestrictedActions",
+      "Sid": "RequireResourceTag",
       "Effect": "Allow",
       "Action": [
+        "acm:DeleteCertificate",
+        "acm:DescribeCertificate",
+        "acm:GetCertificate",
         "autoscaling:CancelInstanceRefresh",
         "autoscaling:Describe*",
         "autoscaling:PutScalingPolicy",
@@ -99,6 +103,22 @@
       "Condition": {
         "StringEqualsIgnoreCase": {
           "aws:ResourceTag/Vendor": "StreamNative"
+        }
+      }
+    },
+    {
+      "Sid": "RequireRequestTag",
+      "Effect": "Allow",
+      "Action": [
+        "acm:AddTagsToCertificate",
+        "acm:ImportCertificate",
+      ],
+      "Resource": [
+        "*"
+      ],
+      "Condition": {
+        "StringEqualsIgnoreCase": {
+          "aws:RequestTag/Vendor": "StreamNative"
         }
       }
     }


### PR DESCRIPTION
This PR adds missing permissions to the `StreamNativeCloudManagementPolicy` which are needed by the control plane.