### PR TITLE
Removed kubeconfig file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ provider "aws" {
 
 provider "helm" {
   kubernetes {
-    config_path = "./${local.cluster_name}-config" # This must match the module input
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
   }
 }
 
@@ -75,7 +77,6 @@ module "sn_cluster" {
   cluster_name             = "sn-cluster-${var.region}"
   cluster_version          = "1.20"
   hosted_zone_id           = "Z04554535IN8Z31SKDVQ2" # Change this to your hosted zone ID
-  kubeconfig_output_path   = "./${local.cluster_name}-config"
   node_pool_instance_types = ["c6i.large"]
   node_pool_desired_size   = 2
   node_pool_min_size       = 1
@@ -370,7 +371,6 @@ You can also disable `kubernetes-external-secrets` by setting the input `enable-
 | <a name="input_istio_settings"></a> [istio\_settings](#input\_istio\_settings) | Additional settings which will be passed to the Helm chart values | `map(any)` | `{}` | no |
 | <a name="input_istio_trust_domain"></a> [istio\_trust\_domain](#input\_istio\_trust\_domain) | The trust domain used for the Istio deployment, which corresponds to the root of a system. This is required when "enable\_istio\_operator" is set to "true". | `string` | `"cluster.local"` | no |
 | <a name="input_kiali_operator_settings"></a> [kiali\_operator\_settings](#input\_kiali\_operator\_settings) | Additional settings which will be passed to the Helm chart values | `map(any)` | `{}` | no |
-| <a name="input_kubeconfig_output_path"></a> [kubeconfig\_output\_path](#input\_kubeconfig\_output\_path) | Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`. | `string` | `"./"` | no |
 | <a name="input_map_additional_aws_accounts"></a> [map\_additional\_aws\_accounts](#input\_map\_additional\_aws\_accounts) | Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap. | `list(string)` | `[]` | no |
 | <a name="input_map_additional_iam_roles"></a> [map\_additional\_iam\_roles](#input\_map\_additional\_iam\_roles) | Additional IAM roles to add to `config-map-aws-auth` ConfigMap. | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_map_additional_iam_users"></a> [map\_additional\_iam\_users](#input\_map\_additional\_iam\_users) | Additional IAM roles to add to `config-map-aws-auth` ConfigMap. | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
@@ -391,7 +391,6 @@ You can also disable `kubernetes-external-secrets` by setting the input `enable-
 | <a name="input_service_domain"></a> [service\_domain](#input\_service\_domain) | The DNS domain for external service endpoints. This must be set when enabling Istio or else the deployment will fail. | `string` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the AWS VPC to use. | `string` | `""` | no |
 | <a name="input_wait_for_cluster_timeout"></a> [wait\_for\_cluster\_timeout](#input\_wait\_for\_cluster\_timeout) | Time in seconds to wait for the newly provisioned EKS cluster's API/healthcheck endpoint to return healthy, before applying the aws-auth configmap. Defaults to 300 seconds in the parent module "terraform-aws-modules/eks/aws", which is often too short. Increase to at least 900 seconds, if needed. See also https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1420. | `number` | `0` | no |
-| <a name="input_write_kubeconfig"></a> [write\_kubeconfig](#input\_write\_kubeconfig) | Whether to write a Kubectl config file containing the cluster configuration. Saved to variable "kubeconfig\_output\_path". | `bool` | `true` | no |
 
 ## Outputs
 
@@ -406,3 +405,4 @@ You can also disable `kubernetes-external-secrets` by setting the input `enable-
 | <a name="output_eks_cluster_identity_oidc_issuer_url"></a> [eks\_cluster\_identity\_oidc\_issuer\_url](#output\_eks\_cluster\_identity\_oidc\_issuer\_url) | The URL for the OIDC issuer created by this module |
 | <a name="output_external_dns_role_arn"></a> [external\_dns\_role\_arn](#output\_external\_dns\_role\_arn) | The IAM Role ARN used by the ExternalDNS configuration |
 | <a name="output_sn_system_namespace"></a> [sn\_system\_namespace](#output\_sn\_system\_namespace) | The namespace used for StreamNative system resources, i.e. operators et all |
+

--- a/examples/example-with-vpc/main.tf
+++ b/examples/example-with-vpc/main.tf
@@ -78,7 +78,9 @@ provider "aws" {
 
 provider "helm" {
   kubernetes {
-    config_path = pathexpand("~/.kube/${local.cluster_name}-config")
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
   }
 }
 

--- a/examples/streamnative-platform/main.tf
+++ b/examples/streamnative-platform/main.tf
@@ -17,24 +17,6 @@
 # under the License.
 #
 
-terraform {
-  required_version = ">=1.0.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">=3.72.0"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "2.2.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">=2.7.1"
-    }
-  }
-}
-
 provider "aws" {
   region = local.region
 }
@@ -44,7 +26,6 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster.token
-    insecure               = false
   }
 }
 
@@ -115,8 +96,7 @@ module "sn_cluster" {
   cluster_name             = local.cluster_name
   cluster_version          = "1.20"
   hosted_zone_id           = "*" # Specify the hosted zone ID where you want DNS records to be created and managed. This scopes access to the External DNS service.
-  kubeconfig_output_path   = "./${local.cluster_name}-config"
-  node_pool_instance_types = ["c6i.large"]
+  node_pool_instance_types = ["c6i.xlarge"]
   node_pool_desired_size   = 1 # This module creates 1 node pool per private subnet. Based on this configuration, the cluster will have 3 node pools with 1 x c6i.large instance, 3 instances total.
   node_pool_min_size       = 1
   node_pool_max_size       = 5

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,6 @@ module "eks" {
   cluster_log_kms_key_id                         = var.cluster_log_kms_key_id
   cluster_log_retention_in_days                  = var.cluster_log_retention_in_days
   enable_irsa                                    = true
-  kubeconfig_output_path                         = var.kubeconfig_output_path
   iam_path                                       = "/StreamNative/"
   manage_cluster_iam_resources                   = true
   manage_worker_iam_resources                    = true
@@ -93,9 +92,8 @@ module "eks" {
   subnets                                        = local.cluster_subnet_ids
   vpc_id                                         = var.vpc_id
   wait_for_cluster_timeout                       = var.wait_for_cluster_timeout // This was added in version 17.1.0, and if set above 0, causes TF to crash.
+  write_kubeconfig                               = false
   # workers_role_name            = aws_iam_role.nodes.name
-  write_kubeconfig = var.write_kubeconfig
-
 
   node_groups = local.node_groups
 

--- a/variables.tf
+++ b/variables.tf
@@ -422,12 +422,6 @@ variable "kiali_operator_settings" {
   type        = map(any)
 }
 
-variable "kubeconfig_output_path" {
-  default     = "./"
-  description = "Where to save the Kubectl config file (if `write_kubeconfig = true`). Assumed to be a directory if the value ends with a forward slash `/`."
-  type        = string
-}
-
 variable "map_additional_aws_accounts" {
   default     = []
   description = "Additional AWS account numbers to add to `config-map-aws-auth` ConfigMap."
@@ -555,10 +549,4 @@ variable "wait_for_cluster_timeout" {
   default     = 0
   description = "Time in seconds to wait for the newly provisioned EKS cluster's API/healthcheck endpoint to return healthy, before applying the aws-auth configmap. Defaults to 300 seconds in the parent module \"terraform-aws-modules/eks/aws\", which is often too short. Increase to at least 900 seconds, if needed. See also https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1420."
   type        = number
-}
-
-variable "write_kubeconfig" {
-  default     = true
-  description = "Whether to write a Kubectl config file containing the cluster configuration. Saved to variable \"kubeconfig_output_path\"."
-  type        = bool
 }


### PR DESCRIPTION
This commit removes the optional ability to write a .kubeconfig file as part of the module output. It is not a requirement, and has been a small source of problems.

In addition to this, the examples have been updated with the correct provider configuration for helm