### PR TITLE
Add support for external_id/source_id and policy updates

### DIFF
--- a/modules/managed-cloud/cloudformation/managed_cloud.yaml
+++ b/modules/managed-cloud/cloudformation/managed_cloud.yaml
@@ -17,25 +17,25 @@ Resources:
         Properties:
             Path: "/StreamNative/"
             RoleName: "StreamNativeCloudBootstrapRole"
-            AssumeRolePolicyDocument: 
+            AssumeRolePolicyDocument:
               Version: '2012-10-17'
               Statement:
               - Sid: AllowStreamNativeVendorAccess
                 Effect: Allow
                 Principal:
-                  AWS: 
+                  AWS:
                     - !Ref VendorSupportRoleArn
                 Action: sts:AssumeRole
             MaxSessionDuration: 3600
             PermissionsBoundary: !Ref PermissionBoundaryPolicy
-            ManagedPolicyArns: 
+            ManagedPolicyArns:
               - !Ref BootstrapPolicy
             Description: "This role is used to bootstrap the StreamNative Cloud within the AWS account. It is limited in scope to the attached policy and also the permission boundary."
-            Tags: 
-              - 
+            Tags:
+              -
                 Key: "Vendor"
                 Value: "StreamNative"
-  
+
     ManagementRole:
         Type: "AWS::IAM::Role"
         Properties:
@@ -60,11 +60,11 @@ Resources:
                     accounts.google.com:aud: !Ref ControlPlaneSAID
             MaxSessionDuration: 3600
             PermissionsBoundary: !Ref PermissionBoundaryPolicy
-            ManagedPolicyArns: 
+            ManagedPolicyArns:
               - !Ref ManagementPolicy
             Description: "This role is used by StreamNative for the day to day management of the StreamNative Cloud deployment."
-            Tags: 
-              - 
+            Tags:
+              -
                 Key: "Vendor"
                 Value: "StreamNative"
 
@@ -178,7 +178,7 @@ Resources:
                 			"Resource": "arn:aws:iam::${AWS::AccountId}:role/StreamNative/*",
                 			"Condition": {
                 				"ArnNotLike": {
-                					"iam:PolicyARN": [ 
+                					"iam:PolicyARN": [
                 						"arn:aws:iam::${AWS::AccountId}:policy/StreamNative/*-AWSLoadBalancerControllerPolicy",
                 						"arn:aws:iam::${AWS::AccountId}:policy/StreamNative/*-CertManagerPolicy",
                 						"arn:aws:iam::${AWS::AccountId}:policy/StreamNative/*-ClusterAutoscalerPolicy",
@@ -251,7 +251,7 @@ Resources:
                 			"Effect": "Allow",
                 			"Action": [
                 				"acm:ListCertificates",
-                				"acm:ListTagsForCertificate",	
+                				"acm:ListTagsForCertificate",
                 				"autoscaling:Describe*",
                 				"dynamodb:ListBackups",
                 				"dynamodb:ListGlobalTables",
@@ -291,6 +291,9 @@ Resources:
                 				"logs:CreateLogGroup",
                 				"logs:DescribeLogGroups",
                 				"logs:ListTagsLogGroup",
+                        "route53:CreateHostedZone",
+                        "route53:ChangeTagsForResource",
+                        "route53:GetChange",
                         "route53:GetHostedZone",
                         "route53:ListHostedZones",
                         "route53:ListTagsForResource",
@@ -343,10 +346,10 @@ Resources:
                 				"ec2:CreateVpc",
                 				"ec2:CreateVpcEndpoint",
                 				"ec2:CreateTags",
+                        "ec2:*TransitGateway*",
                 				"eks:Create*",
                         "eks:RegisterCluster",
-                				"eks:TagResource",
-                        "route53:CreateHostedZone"
+                				"eks:TagResource"
                 			],
                 			"Resource": "*",
                 			"Condition": {
@@ -388,6 +391,8 @@ Resources:
                 				"ec2:Release*",
                 				"ec2:Revoke*",
                 				"ec2:RunInstances",
+                        "ec2:TerminateInstances",
+                        "ec2:*TransitGateway*",
                 				"ec2:Update*",
                         "eks:DeleteAddon",
                         "eks:DeleteCluster",
@@ -396,8 +401,7 @@ Resources:
                         "eks:DisassociateIdentityProviderConfig",
                 				"eks:U*",
                 				"logs:DeleteLogGroup",
-                				"logs:PutRetentionPolicy",
-                        "route53:DeleteHostedZone"
+                				"logs:PutRetentionPolicy"
                 			],
                 			"Resource": "*",
                 			"Condition": {

--- a/modules/managed-cloud/files/bootstrap_role_iam_policy.json.tpl
+++ b/modules/managed-cloud/files/bootstrap_role_iam_policy.json.tpl
@@ -46,6 +46,9 @@
 				"logs:CreateLogGroup",
 				"logs:DescribeLogGroups",
 				"logs:ListTagsLogGroup",
+				"route53:CreateHostedZone",
+				"route53:ChangeTagsForResource",
+				"route53:GetChange",
 				"route53:GetHostedZone",
 				"route53:ListHostedZones",
 				"route53:ListTagsForResource",
@@ -98,10 +101,10 @@
 				"ec2:CreateVpc",
 				"ec2:CreateVpcEndpoint",
 				"ec2:CreateTags",
+        "ec2:*TransitGateway*",
 				"eks:Create*",
 				"eks:RegisterCluster",
-				"eks:TagResource",
-				"route53:CreateHostedZone"
+				"eks:TagResource"
 			],
 			"Resource": "*",
 			"Condition": {
@@ -143,6 +146,8 @@
 				"ec2:Release*",
 				"ec2:Revoke*",
 				"ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ec2:*TransitGateway*",
 				"ec2:Update*",
 				"eks:DeleteAddon",
 				"eks:DeleteCluster",
@@ -151,8 +156,7 @@
 				"eks:DisassociateIdentityProviderConfig",
 				"eks:U*",
 				"logs:DeleteLogGroup",
-				"logs:PutRetentionPolicy",
-				"route53:DeleteHostedZone"
+				"logs:PutRetentionPolicy"
 			],
 			"Resource": "*",
 			"Condition": {

--- a/modules/managed-cloud/files/permission_boundary_iam_policy.json.tpl
+++ b/modules/managed-cloud/files/permission_boundary_iam_policy.json.tpl
@@ -102,7 +102,7 @@
 			"Resource": "arn:aws:iam::${account_id}:role/StreamNative/*",
 			"Condition": {
 				"ArnNotLike": {
-					"iam:PolicyARN": [ 
+					"iam:PolicyARN": [
 						"arn:aws:iam::${account_id}:policy/StreamNative/*-AWSLoadBalancerControllerPolicy",
 						"arn:aws:iam::${account_id}:policy/StreamNative/*-CertManagerPolicy",
 						"arn:aws:iam::${account_id}:policy/StreamNative/*-ClusterAutoscalerPolicy",
@@ -153,6 +153,8 @@
 			],
 			"Resource": [
 				"arn:aws:iam:::policy/StreamNative/StreamNativeCloudPermissionBoundary",
+				"arn:aws:iam:::policy/StreamNative/StreamNativeCloudBootstrapPolicy",
+				"arn:aws:iam:::policy/StreamNative/StreamNativeCloudManagementPolicy",
 				"arn:aws:iam::${account_id}:role/StreamNative/StreamNativeBootstrapRole",
 				"arn:aws:iam::${account_id}:role/StreamNative/StreamNativeManagementRole"
 			]

--- a/modules/managed-cloud/variables.tf
+++ b/modules/managed-cloud/variables.tf
@@ -25,7 +25,26 @@ variable "create_bootstrap_role" {
 }
 
 variable "region" {
-  description = "The AWS region where your instance of StreamNative Cloud is deployed, i.e. \"us-west-2\""
+  default     = "*"
+  description = "The AWS region where your instance of StreamNative Cloud is deployed. Defaults to all regions \"*\""
+  type        = string
+}
+
+variable "external_id" {
+  default     = ""
+  description = "The external ID, provided by StreamNative, which is used for all assume role calls. If not provided, no check for external_id is added. (NOTE: a future version will force the passing of this parameter)"
+  type        = string
+}
+
+variable "source_identities" {
+  default     = []
+  description = "Place an additional constraint on source identity, disabled by default and only to be used if specified by StreamNative"
+  type        = list
+}
+
+variable "source_identity_test" {
+  default     = "ForAnyValue:StringLike"
+  description = "The test to use for source identity"
   type        = string
 }
 
@@ -42,6 +61,7 @@ variable "streamnative_google_account_id" {
 }
 
 variable "streamnative_vendor_access_role_arn" {
+  default     = "arn:aws:iam::311022431024:role/cloud-manager"
   description = "The arn for the IAM principle (role) provided by StreamNative. This role is used exclusively by StreamNative (with strict permissions) for vendor access into your AWS account"
   type        = string
 }


### PR DESCRIPTION
This is commits makes a few policy changes:
- further locks down permission boundary
- adds the ability to manage transit gateway
- fixes support for route53 management
- adds support to terminate instances for bad instances

This also changes to add support for external_id and source identity