### PR TITLE
Fix missing parameters in root-example

### DIFF
--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -17,15 +17,24 @@
 # under the License.
 #
 
+locals {
+  cluster_name = "sn-aws"
+}
+
+variable "region" {
+  type        = string
+  description = "The region of AWS"
+}
+
 #######
 ### These data sources are required by the Kubernetes and Helm providers in order to connect to the newly provisioned cluster
 #######
 data "aws_eks_cluster" "cluster" {
-  name = module.eks_cluster.eks_cluster_id
+  name = module.sn_cluster.eks_cluster_id
 }
 
 data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks_cluster.eks_cluster_id
+  name = module.sn_cluster.eks_cluster_id
 }
 
 provider "aws" {


### PR DESCRIPTION

Fixes #57 

### Motivation

The `examples/root-example` cannot run because of missing parameters.

### Modifications

Add missing parameters.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - Execute `terraform plan` under `examples/root-example`

### Documentation

- [x] `no-need-doc` 
  

