### PR TITLE
Fixes tiered-storage-resources module when using latest AWS provider

### DIFF
--- a/modules/tiered-storage-resources/README.md
+++ b/modules/tiered-storage-resources/README.md
@@ -57,6 +57,8 @@ No modules.
 | [aws_iam_role.tiered_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.tiered_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_bucket.tiered_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.tiered_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.tiered_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.tiered_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tiered_storage_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -68,22 +70,14 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | AWS partition: 'aws', 'aws-cn', or 'aws-us-gov' | `string` | `"aws"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of your EKS cluster and associated resources | `string` | n/a | yes |
-| <a name="input_create_iam_policy_for_tiered_storage"></a> [create\_iam\_policy\_for\_tiered\_storage](#input\_create\_iam\_policy\_for\_tiered\_storage) | Whether to create the IAM policy used by Pulsar's tiered storage offloading. For enhanced security, we allow for these IAM policies to be created seperately from this module. Defaults to "true". If set to "false", you must provide the ARN for the IAM policy needed for Velero. | `bool` | `true` | no |
-| <a name="input_iam_policy_arn"></a> [iam\_policy\_arn](#input\_iam\_policy\_arn) | The arn for the IAM policy used for Pulsar's tiered storage offloading. For enhanced security, we allow for IAM policies used by cluster addon services to be created seperately from this module. This is only required if the input "create\_iam\_policy\_for\_tiered\_storage" is set to "false". If created elsewhere, the expected name of the policy is "StreamNativeCloudVeleroBackupPolicy". | `string` | `null` | no |
+| <a name="input_create_iam_policy_for_tiered_storage"></a> [create\_iam\_policy\_for\_tiered\_storage](#input\_create\_iam\_policy\_for\_tiered\_storage) | Whether to create the IAM policy used by Pulsar's tiered storage offloading. For enhanced security, we allow for these IAM policies to be created seperately from this module. Defaults to "true". If set to "false", you must provide the ARN for the IAM policy needed for tiered storage offloading to function. | `bool` | `true` | no |
+| <a name="input_iam_policy_arn"></a> [iam\_policy\_arn](#input\_iam\_policy\_arn) | The arn for the IAM policy used for Pulsar's tiered storage offloading. For enhanced security, we allow for IAM policies used by cluster addon services to be created seperately from this module. This is only required if the input "create\_iam\_policy\_for\_tiered\_storage" is set to "false". If created elsewhere, the expected name of the policy is "StreamNativeCloudTieredStoragedPolicy". | `string` | `null` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The KMS key ID to use for server side encryption. Defaults to "aws/s3". | `string` | `"aws/s3"` | no |
 | <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | The OIDC issuer for the EKS cluster | `string` | n/a | yes |
 | <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | If required, provide the ARN of the IAM permissions boundary to use for restricting StreamNative's vendor access. | `string` | `null` | no |
 | <a name="input_pulsar_namespace"></a> [pulsar\_namespace](#input\_pulsar\_namespace) | The kubernetes namespace where Pulsar has been deployed. This is required to set the appropriate policy permissions for IRSA, which grants the Kubernetes Service Account access to use the IAM role | `string` | n/a | yes |
 | <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The name of the kubernetes service account to by tiered storage offloading. Defaults to "pulsar". This is required to set the appropriate policy permissions for IRSA, which grants the Kubernetes Service Account access to use the IAM role | `string` | `"pulsar"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be added to the bucket and corresponding resources | `map(string)` | `{}` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The arn of the role used for Pulsar's tiered storage offloading. This needs to be annotated on the corresponding Kubernetes Service account in order for IRSA to work properly, e.g. "eks.amazonaws.com/role-arn" : "<this\_arn>" |
-| <a name="output_role_name"></a> [role\_name](#output\_role\_name) | The name of the role used for Pulsar's tiered storage offloading |
-| <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | The name of the bucket used for Pulsar's tiered storage offloading |
-| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The arn of the bucket used for Pulsar's tiered storage offloading |
 
 ## Outputs
 

--- a/modules/tiered-storage-resources/variables.tf
+++ b/modules/tiered-storage-resources/variables.tf
@@ -40,6 +40,12 @@ variable "iam_policy_arn" {
   type        = string
 }
 
+variable "kms_key_id" {
+  default     = "aws/s3"
+  description = "The KMS key ID to use for server side encryption. Defaults to \"aws/s3\"."
+  type        = string
+}
+
 variable "oidc_issuer" {
   description = "The OIDC issuer for the EKS cluster"
   type        = string

--- a/modules/tiered-storage-resources/versions.tf
+++ b/modules/tiered-storage-resources/versions.tf
@@ -22,7 +22,7 @@ terraform {
 
   required_providers {
     aws = {
-      version = ">= 3.61.0"
+      version = ">= 4.0.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #59

### Motivation

An update to the AWS provider broke the `tiered-storage-resources` module.

### Modifications

- Removed server side encryption and ACL configurations from the s3 bucket terraform resource, in favor of their own.
- Added a new input variable called `kms_key_id` to the module to pass a custom KMS key ID to use for bucket encryption (uses the account default s3 key by default)

### Verifying this change

- [X] Successfully ran the [sn-platform](https://github.com/streamnative/terraform-aws-cloud/blob/master/examples/streamnative-platform/main.tf) example module

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 
  
- [X] `no-need-doc` 

