### PR TITLE
Improved tiered-storage and vault submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,4 +405,4 @@ You can also disable `kubernetes-external-secrets` by setting the input `enable-
 | <a name="output_eks_cluster_identity_oidc_issuer_url"></a> [eks\_cluster\_identity\_oidc\_issuer\_url](#output\_eks\_cluster\_identity\_oidc\_issuer\_url) | The URL for the OIDC issuer created by this module |
 | <a name="output_external_dns_role_arn"></a> [external\_dns\_role\_arn](#output\_external\_dns\_role\_arn) | The IAM Role ARN used by the ExternalDNS configuration |
 | <a name="output_sn_system_namespace"></a> [sn\_system\_namespace](#output\_sn\_system\_namespace) | The namespace used for StreamNative system resources, i.e. operators et all |
-
+| <a name="output_worker_iam_role_arn"></a> [worker\_iam\_role\_arn](#output\_worker\_iam\_role\_arn) | The IAM Role ARN used by the Worker configuration |

--- a/modules/tiered-storage-resources/main.tf
+++ b/modules/tiered-storage-resources/main.tf
@@ -89,6 +89,12 @@ resource "aws_iam_role" "tiered_storage" {
   path                 = "/StreamNative/"
   permissions_boundary = var.permissions_boundary_arn
   tags                 = merge({ "Vendor" = "StreamNative" }, var.tags)
+
+  lifecycle {
+    ignore_changes = [
+      assume_role_policy
+    ]
+  }
 }
 
 resource "aws_iam_policy" "tiered_storage" {
@@ -98,6 +104,12 @@ resource "aws_iam_policy" "tiered_storage" {
   path        = "/StreamNative/"
   policy      = data.aws_iam_policy_document.tiered_storage.json
   tags        = merge({ "Vendor" = "StreamNative" }, var.tags)
+
+  lifecycle {
+    ignore_changes = [
+      policy
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "tiered_storage" {

--- a/modules/vault-resources/main.tf
+++ b/modules/vault-resources/main.tf
@@ -126,6 +126,12 @@ resource "aws_iam_role" "vault" {
   path                 = "/StreamNative/"
   permissions_boundary = var.permissions_boundary_arn
   tags                 = merge({ "Vendor" = "StreamNative" }, var.tags)
+
+  lifecycle {
+    ignore_changes = [
+      assume_role_policy
+    ]
+  }
 }
 
 resource "aws_iam_policy" "vault" {
@@ -135,6 +141,12 @@ resource "aws_iam_policy" "vault" {
   path        = "/StreamNative/"
   policy      = data.aws_iam_policy_document.vault.json
   tags        = merge({ "Vendor" = "StreamNative" }, var.tags)
+
+  lifecycle {
+    ignore_changes = [
+      policy
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "vault" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,3 +61,8 @@ output "sn_system_namespace" {
   value       = join("", kubernetes_namespace.sn_system.*.id)
   description = "The namespace used for StreamNative system resources, i.e. operators et all"
 }
+
+output "worker_iam_role_arn" {
+  value       = module.eks.worker_iam_role_arn
+  description = "The IAM Role ARN used by the Worker configuration"
+}


### PR DESCRIPTION
## Overview
The resources created by the tiered-storage and vault modules would churn due to a computed value change from their parent S3 bucket. This resulted in a no-op change every terraform apply. Added a lifecycle to the resource to ignore any reconcilation changes.

Also added a new output to capture the worker node role arn.