### PR TITLE
Remove vpc icdr validation to support more needs

### DIFF
--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -59,7 +59,7 @@ variable "tags" {
 
 variable "vpc_cidr" {
   validation {
-    condition     = can(regex("^10\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}/16", var.vpc_cidr))
-    error_message = "The vpc_cidr must be a 10.x.x.x range with /16 CIDR."
+    condition     = can(regex("^10\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}/\\d{1,2}", var.vpc_cidr))
+    error_message = "The vpc_cidr must be a 10.x.x.x range with CIDR."
   }
 }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #63 

### Motivation

The VPC CIDR validation limits user's requirements.

### Modifications

Remove the cidr limits. So that user can specify vpc cidr from `10.x.x.x/0` to `10.x.x.x/32`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

