### PR TITLE
Update addons to latest versions

### DIFF
--- a/istio.tf
+++ b/istio.tf
@@ -34,7 +34,7 @@ locals {
 module "istio" {
   count = var.enable_istio ? 1 : 0
 
-  source = "github.com/streamnative/terraform-helm-charts//modules/istio-operator?ref=master"
+  source = "github.com/streamnative/terraform-helm-charts//modules/istio-operator?ref=v0.8.4"
 
   enable_istio_operator = true
   enable_kiali_operator = true

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "aws_load_balancer_controller_helm_chart_repository" {
 }
 
 variable "aws_load_balancer_controller_helm_chart_version" {
-  default     = "1.3.2"
+  default     = "1.4.2"
   description = "The version of the Helm chart to use for the AWS Load Balancer Controller. The current version can be found in github: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/helm/aws-load-balancer-controller/Chart.yaml."
   type        = string
 }
@@ -102,13 +102,13 @@ variable "cert_manager_helm_chart_name" {
 }
 
 variable "cert_manager_helm_chart_repository" {
-  default     = "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami"
+  default     = "https://charts.bitnami.com/bitnami"
   description = "The repository containing the cert-manager helm chart."
   type        = string
 }
 
 variable "cert_manager_helm_chart_version" {
-  default     = "0.1.27"
+  default     = "0.6.2"
   description = "Helm chart version for the cert-manager. See https://github.com/bitnami/charts/tree/master/bitnami/cert-manager for version releases."
   type        = string
 }
@@ -138,7 +138,7 @@ variable "cluster_autoscaler_helm_chart_repository" {
 }
 
 variable "cluster_autoscaler_helm_chart_version" {
-  default     = "9.10.8"
+  default     = "9.19.2"
   description = "Helm chart version for the cluster-autoscaler. Defaults to \"9.10.4\". See https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler for more details."
   type        = string
 }
@@ -197,7 +197,7 @@ variable "csi_helm_chart_repository" {
 }
 
 variable "csi_helm_chart_version" {
-  default     = "2.4.1"
+  default     = "2.8.0"
   description = "Helm chart version for CSI"
   type        = string
 }
@@ -293,8 +293,8 @@ variable "external_dns_helm_chart_repository" {
 }
 
 variable "external_dns_helm_chart_version" {
-  default     = "5.5.2"
-  description = "Helm chart version for ExternalDNS. Defaults to \"4.9.0\". See https://hub.helm.sh/charts/bitnami/external-dns for updates."
+  default     = "6.5.6"
+  description = "Helm chart version for ExternalDNS. See https://hub.helm.sh/charts/bitnami/external-dns for updates."
   type        = string
 }
 
@@ -492,7 +492,7 @@ variable "node_termination_handler_settings" {
 }
 
 variable "node_termination_handler_chart_version" {
-  default     = "0.16.0"
+  default     = "0.18.5"
   description = "The version of the Helm chart to use for the AWS Node Termination Handler."
   type        = string
 }


### PR DESCRIPTION
### Motivation
Routine updates to the various cluster add-ons and data plane components we install.

### Modifications
- `aws-load-balancer-controller` > 1.4.2
- `cert-manager` > 0.6.2
- `cluster-autoscaler` > 9.19.2
- `csi` > 2.8.0
- `external-dns` > 6.5.6
- `node-termination-handler` > 0.18.5

### Verifying this change

- [ ] Upgrade existing test environment
- [ ] Verify components

### Documentation

- [ ] `doc` 


