### PR TITLE
Extra eks node group

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,14 @@ variable "region" {
 module "sn_cluster" {
   source = "streamnative/cloud/aws"
 
-  cluster_name             = "sn-cluster-${var.region}"
-  cluster_version          = "1.20"
-  hosted_zone_id           = "Z04554535IN8Z31SKDVQ2" # Change this to your hosted zone ID
-  node_pool_instance_types = ["c6i.xlarge"]
-  node_pool_desired_size   = 2
-  node_pool_min_size       = 1
-  node_pool_max_size       = 6
+  cluster_name                   = "sn-cluster-${var.region}"
+  cluster_version                = "1.20"
+  hosted_zone_id                 = "Z04554535IN8Z31SKDVQ2" # Change this to your hosted zone ID
+  node_pool_instance_types       = ["c6i.xlarge"]
+  extra_node_pool_instance_types = ["c6i.2xlarge"] # Defaults to empty list. Means don't create extra node pool
+  node_pool_desired_size         = 2
+  node_pool_min_size             = 1
+  node_pool_max_size             = 6
 
   ## Note: EKS requires two subnets, each in their own availability zone
   public_subnet_ids  = ["subnet-abcde012", "subnet-bcde012a"]
@@ -403,6 +404,7 @@ You can also disable `kubernetes-external-secrets` by setting the input `enable-
 | <a name="input_node_pool_disk_size"></a> [node\_pool\_disk\_size](#input\_node\_pool\_disk\_size) | Disk size in GiB for worker nodes in the node pool. Defaults to 50. | `number` | `50` | no |
 | <a name="input_node_pool_disk_type"></a> [node\_pool\_disk\_type](#input\_node\_pool\_disk\_type) | Disk type for worker nodes in the node pool. Defaults to gp3. | `string` | `"gp3"` | no |
 | <a name="input_node_pool_instance_types"></a> [node\_pool\_instance\_types](#input\_node\_pool\_instance\_types) | Set of instance types associated with the EKS Node Group. Defaults to ["c6i.large"]. | `list(string)` | <pre>[<br>  "c6i.large"<br>]</pre> | no |
+| <a name="input_extra_node_pool_instance_types"></a> [extra\_node\_pool\_instance\_types](#input\_extra\_node\_pool\_instance\_types) | Set of instance types of an extra node pool. Same properties as default node pool except name and instance types. Defaults to []. | `list(string)` | <pre>[]</pre> | no |
 | <a name="input_node_pool_labels"></a> [node\_pool\_labels](#input\_node\_pool\_labels) | A map of kubernetes labels to add to the node pool. | `map(string)` | `{}` | no |
 | <a name="input_node_pool_max_size"></a> [node\_pool\_max\_size](#input\_node\_pool\_max\_size) | The maximum size of the node pool Autoscaling group. | `number` | n/a | yes |
 | <a name="input_node_pool_min_size"></a> [node\_pool\_min\_size](#input\_node\_pool\_min\_size) | The minimum size of the node pool AutoScaling group. | `number` | `1` | no |

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ locals {
   }
 
   snc_node_config       = { for i, v in var.private_subnet_ids : "snc-node-pool${i}" => merge(local.node_pool_defaults, { subnets = [var.private_subnet_ids[i]], name = "snc-node-pool${i}" }) }
-  snc_extra_node_config = (length(var.extra_node_pool_instance_types) == 0 ? {} : { for i, v in var.private_subnet_ids : "snc-extra-node-pool$[i]" => merge(local.node_pool_defaults, { subnets = [var.private_subnet_ids[i]], name = "snc-extra-node-pool${i}", instance_types = var.extra_node_pool_instance_types }) })
+  snc_extra_node_config = (length(var.extra_node_pool_instance_types) == 0 ? {} : { for i, v in var.private_subnet_ids : "snc-extra-node-pool${i}" => merge(local.node_pool_defaults, { subnets = [var.private_subnet_ids[i]], name = "snc-extra-node-pool${i}", instance_types = var.extra_node_pool_instance_types }) })
   snc_func_config       = { for i, v in var.private_subnet_ids : "snc-func-pool${i}" => merge(local.func_pool_defaults, { subnets = [var.private_subnet_ids[i]], name = "snc-func-pool${i}" }) }
   node_groups           = (var.enable_func_pool ? merge(local.snc_node_config, local.snc_func_config, local.snc_extra_node_config) : merge(local.snc_node_config, local.snc_extra_node_config))
 }

--- a/main.tf
+++ b/main.tf
@@ -77,9 +77,10 @@ locals {
     taints               = []
   }
 
-  snc_node_config = { for i, v in var.private_subnet_ids : "snc-node-pool${i}" => merge(local.node_pool_defaults, { subnets = [var.private_subnet_ids[i]], name = "snc-node-pool${i}" }) }
-  snc_func_config = { for i, v in var.private_subnet_ids : "snc-func-pool${i}" => merge(local.func_pool_defaults, { subnets = [var.private_subnet_ids[i]], name = "snc-func-pool${i}" }) }
-  node_groups     = (var.enable_func_pool ? merge(local.snc_node_config, local.snc_func_config) : local.snc_node_config)
+  snc_node_config       = { for i, v in var.private_subnet_ids : "snc-node-pool${i}" => merge(local.node_pool_defaults, { subnets = [var.private_subnet_ids[i]], name = "snc-node-pool${i}" }) }
+  snc_extra_node_config = (length(var.extra_node_pool_instance_types) == 0 ? {} : { for i, v in var.private_subnet_ids : "snc-extra-node-pool$[i]" => merge(local.node_pool_defaults, { subnets = [var.private_subnet_ids[i]], name = "snc-extra-node-pool${i}", instance_types = var.extra_node_pool_instance_types }) })
+  snc_func_config       = { for i, v in var.private_subnet_ids : "snc-func-pool${i}" => merge(local.func_pool_defaults, { subnets = [var.private_subnet_ids[i]], name = "snc-func-pool${i}" }) }
+  node_groups           = (var.enable_func_pool ? merge(local.snc_node_config, local.snc_func_config, local.snc_extra_node_config) : merge(local.snc_node_config, local.snc_extra_node_config))
 }
 
 module "eks" {

--- a/variables.tf
+++ b/variables.tf
@@ -575,6 +575,12 @@ variable "node_pool_instance_types" {
   type        = list(string)
 }
 
+variable "extra_node_pool_instance_types" {
+  default     = []
+  description = "Set of instance types of an extra node pool. Same properties as default node pool except name and instance types."
+  type        = list(string)
+}
+
 variable "node_pool_labels" {
   default     = {}
   description = "A map of kubernetes labels to add to the node pool."


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #84 

### Motivation

This is a small change to allow adding an `extra` node pool with a different instance type.  Therefore we can use a `blue`/`green` strategy to switch instances from the `default` node pool to a `extra` node pool via taint/drain. This keeps backward compatibility - the node group names are not changed, it can be used on previously created cluster/node groups.


### Modifications

Add a `extra_node_pool_instance_types` variable

### Verifying this change

- [X] Validated in test environment

### Documentation

Check the box below.

Need to update docs? 
  
- [x] `doc` 
  
  (If this PR contains doc changes)

