### PR TITLE
Add missing annotation to istio-ingressgateway service

### DIFF
--- a/istio.tf
+++ b/istio.tf
@@ -22,11 +22,13 @@ locals {
     internet_facing = {
       "service.beta.kubernetes.io/aws-load-balancer-scheme" = "internet-facing"
       "service.beta.kubernetes.io/aws-load-balancer-type"   = "nlb"
+      "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags" = "Vendor=StreamNative"
     },
     internal_only = {
       "service.beta.kubernetes.io/aws-load-balancer-internal" : "true"
       "service.beta.kubernetes.io/aws-load-balancer-scheme" = "internal"
       "service.beta.kubernetes.io/aws-load-balancer-type"   = "nlb"
+      "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags" = "Vendor=StreamNative"
     }
   }
 }
@@ -60,6 +62,7 @@ module "istio" {
   kiali_operator_settings                   = var.kiali_operator_settings
 
   depends_on = [
-    helm_release.cert_issuer
+    helm_release.cert_issuer,
+    helm_release.aws_load_balancer_controller
   ]
 }


### PR DESCRIPTION
### Motivation
The `Vendor = StreamNative` tag was not propegating to the Istio Ingress Gateway resource through the AWS Load Balancer Controller. This PR addresses this by adding an annotation directly, rather than relying on default tags to get applied by the controller.

Also added a dependency on the AWS Load Balancer Controller during initial install.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [X] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

