### PR TITLE
Fix desired size of eks node group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ terraform.rc
 .DS_Store
 .vscode/
 .idea/
+
+.terraform.lock.hcl

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,6 @@ locals {
           subnet_ids     = [data.aws_subnet.private_subnets[i].id]
           instance_types = [instance_type]
           name           = "snc-${split(".", instance_type)[1]}-${data.aws_subnet.private_subnets[i].availability_zone}"
-          desired_size   = split(".", instance_type)[1] == "xlarge" ? 1 : 0
           labels         = merge(var.node_pool_labels, { "cloud.streamnative.io/instance-type" = lookup(local.compute_units, split(".", instance_type)[1], "null") })
         }
       ]


### PR DESCRIPTION
### Motivation
Encountering error `"invalid desiredSize"` while applying with below input variables:

```
node_pool_min_size = 1
node_pool_max_size = 12
node_pool_desired_size = 1
node_pool_instance_types = ["c6i.2xlarge"]
```

That's caused by the computed desired size via `node_pool_instance_types` could be 0., which  violates the rule "Desired number of nodes should not be lower than the minimum number of nodes that the group can scale out to." 

Actually the `desired_size` has already been assigned in its above code block `node_group_defaults`: https://github.com/streamnative/terraform-aws-cloud/blob/e0e7315f9a49a04b18fe7264aa8f0cb6c7a92ea9/main.tf#L82

We should just respect it.

### Modifications

- Remove the duplicated `desired_size` assignment line

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
 
- [x] `no-need-doc` 
 

