### PR TITLE
Prepare to bump to AWS 19.x module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ locals {
   }
 
   node_group_defaults = {
+    create_security_group = false
     ami_id = var.node_pool_ami_id
     block_device_mappings = {
       xvda = {
@@ -162,7 +163,7 @@ locals {
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "18.30.2"
+  version = "18.30.2" #"19.6.0"
 
   ######################################################################################################
   ### This section takes into account the breaking changes made in v18.X of the community EKS module ###


### PR DESCRIPTION
Part of the upgrade notes for the module for 18.x to 19.x is that they are removing a creating a security group by default. For the upgrade from 18.x to 19.x, their guide says to first set a value to false, run, then do the upgrade to 19.x https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-19.0.md#eks-managed-node-groups

I'm not upgrading to 19.x yet but it would be good to be ready for this upgrade preemptively.