### PR TITLE
[Functions] Install Cilium into Pool Members (EKS) 

### DIFF
--- a/cilium.tf
+++ b/cilium.tf
@@ -1,0 +1,72 @@
+# Copyright 2023 StreamNative, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "enable_cilium" {
+  default     = false
+  description = "Enables Cilium on the cluster. Set to \"false\" by default."
+  type        = bool
+}
+
+variable "cilium_helm_chart_name" {
+  default     = "cilium"
+  description = "The name of the Helm chart in the repository for Cilium."
+  type        = string
+}
+
+variable "cilium_helm_chart_repository" {
+  default     = "https://helm.cilium.io"
+  description = "The repository containing the Cilium helm chart."
+  type        = string
+}
+
+variable "cilium_helm_chart_version" {
+  default     = "1.13.1"
+  description = "Helm chart version for Cilium. See https://artifacthub.io/packages/helm/cilium/cilium for updates."
+  type        = string
+}
+
+resource "helm_release" "cilium" {
+  count           = var.enable_cilium ? 1 : 0
+  name            = "cilium"
+  namespace       = "kube-system"
+  repository      = var.cilium_helm_chart_repository
+  chart           = var.cilium_helm_chart_name
+  version         = var.cilium_helm_chart_version
+  atomic          = false
+  cleanup_on_fail = false
+  timeout         = 300
+
+  values = [yamlencode({
+    cluster = {
+      id = 0
+      name = var.cluster_name
+    }
+    cni = {
+      chainingMode = "aws-cni"
+      exclusive = false
+    }
+    enableIPv4Masquerade = false
+    enableIPv6Masquerade = false
+    tunnel = "disabled"
+    encryption = {
+      enabled = false
+    }
+    endpointRoutes = {
+      enabled = true
+    }
+    nodeinit = {
+      enabled = true
+    }
+  })]
+}

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,18 @@ locals {
     "8xlarge" = "Large"
   }
 
+  computed_node_taints = merge(
+    var.enable_cilium ? {
+      cilium = {
+        key    = "node.cilium.io/agent-not-ready"
+        value  = true
+        effect = "NO_EXECUTE"
+      }
+    } : {}
+  )
+
+  node_pool_taints = merge(var.node_pool_taints, local.computed_node_taints)
+
   node_group_defaults = {
     create_security_group = false
     ami_id = var.node_pool_ami_id
@@ -82,7 +94,7 @@ locals {
     min_size                = var.node_pool_min_size
     max_size                = var.node_pool_max_size
     pre_bootstrap_user_data = var.node_pool_pre_userdata
-    taints                  = var.node_pool_taints
+    taints                  = local.node_pool_taints
     tags = merge(var.node_pool_tags, local.tags, {
       "k8s.io/cluster-autoscaler/enabled"                      = "true",
       format("k8s.io/cluster-autoscaler/%s", var.cluster_name) = "owned",


### PR DESCRIPTION
<!--
  ~ Copyright 2023 StreamNative, Inc.
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Related to: https://github.com/streamnative/argo/issues/251

Similar to: https://github.com/streamnative/terraform-google-cloud/pull/23

### Motivation

Installs Cilium CNI into EKS pool members, as per the [Cilium installation guide](https://docs.cilium.io/en/latest/installation/cni-chaining-aws-cni/).

### Modifications
- new Helm release: cilium with AWS-specific settings (incl. aws-vpc CNI chaining)
- node taint when Cilium is enabled

### Verifying this change

This change is manually tested.
- set `enable_cilium` to `true`
- after installation, apply a Cilium network policy (see below)
- run a pod with labels that simulate those of a Function pod (see below)
- from within the pod, do `wget google.com` to see that external access is blocked.
- retry the experiment without the pods labels, to see that external access is not blocked.

To launch the pod:
```
kubectl run -n default -it --rm --restart=Never myfunction -l "compute.functionmesh.io/app=function-mesh,compute.functionmesh.io/component=source"  --image busybox:latest -- sh
```

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
Internal.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

Network policy for test purposes:

```yaml
apiVersion: cilium.io/v2
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: netpolicy-pf-allow-egress
spec:
  egress:
  - toEntities:
    - kube-apiserver
  - toEndpoints:
    - matchLabels:
        k8s-app: kube-dns
        k8s:io.kubernetes.pod.namespace: kube-system
    toPorts:
    - ports:
      - port: "53"
        protocol: UDP
      - port: "53"
        protocol: TCP
  - toEndpoints:
    - matchLabels:
        app: istiod
        k8s:io.kubernetes.pod.namespace: istio-system
    toPorts:
    - ports:
      - port: "15010"
        protocol: TCP
      - port: "15012"
        protocol: TCP
  - toEndpoints:
    - matchLabels:
        cloud.streamnative.io/app: pulsar
        cloud.streamnative.io/component: broker
  endpointSelector:
    matchExpressions:
    - key: compute.functionmesh.io/app
      operator: In
      values:
      - function-mesh
    - key: compute.functionmesh.io/component
      operator: In
      values:
      - function
      - source
      - sink
```