### PR TITLE
feat: Add IMDSv2 to AWS by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ locals {
     max_size                = var.node_pool_max_size
     pre_bootstrap_user_data = var.node_pool_pre_userdata
     taints                  = local.node_pool_taints
-    metadata_http_tokens    = "required"
+    metadata_http_tokens    = var.metadata_http_tokens
     tags = merge(var.node_pool_tags, local.tags, {
       "k8s.io/cluster-autoscaler/enabled"                      = "true",
       format("k8s.io/cluster-autoscaler/%s", var.cluster_name) = "owned",
@@ -130,7 +130,7 @@ locals {
           min_size       = var.node_pool_min_size
           max_size       = var.node_pool_max_size
           labels         = tomap(merge(var.node_pool_labels, { "cloud.streamnative.io/instance-type" = lookup(local.compute_units, split(".", instance_type)[1], "null") }))
-          metadata_http_tokens    = "required"
+          metadata_http_tokens    = var.metadata_http_tokens
         }
       ]
     ]) : "${node_group.name}" => node_group
@@ -157,7 +157,7 @@ locals {
         "cloud.streamnative.io/instance-type"  = "Small"
         "cloud.streamnative.io/instance-group" = "Core"
       }))
-      metadata_http_tokens    = "required"
+      metadata_http_tokens    = var.metadata_http_tokens
     }
   })
 

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,7 @@ locals {
     max_size                = var.node_pool_max_size
     pre_bootstrap_user_data = var.node_pool_pre_userdata
     taints                  = local.node_pool_taints
+    metadata_http_tokens    = "required"
     tags = merge(var.node_pool_tags, local.tags, {
       "k8s.io/cluster-autoscaler/enabled"                      = "true",
       format("k8s.io/cluster-autoscaler/%s", var.cluster_name) = "owned",
@@ -129,6 +130,7 @@ locals {
           min_size       = var.node_pool_min_size
           max_size       = var.node_pool_max_size
           labels         = tomap(merge(var.node_pool_labels, { "cloud.streamnative.io/instance-type" = lookup(local.compute_units, split(".", instance_type)[1], "null") }))
+          metadata_http_tokens    = "required"
         }
       ]
     ]) : "${node_group.name}" => node_group
@@ -155,6 +157,7 @@ locals {
         "cloud.streamnative.io/instance-type"  = "Small"
         "cloud.streamnative.io/instance-group" = "Core"
       }))
+      metadata_http_tokens    = "required"
     }
   })
 

--- a/variables.tf
+++ b/variables.tf
@@ -369,6 +369,12 @@ variable "map_additional_iam_roles" {
   }))
 }
 
+variable "metadata_http_tokens" {
+  default     = "optional"
+  description = "Require tokens or not, setting to 'required' enables IMDSv2"
+  type        = string
+}
+
 variable "metrics_server_helm_chart_name" {
   default     = "metrics-server"
   description = "The name of the helm release to install"


### PR DESCRIPTION
Master Issue: #1197

### Motivation

Enable IMDSv2 by default for AWS clusters

### Modifications

Update the module to enable IMDSv2 at the node pool level

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

This change added tests and can be verified as follows:

- Enabling on existing cluster to verify the BYOC env still functions

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  Default security upgrade that should be standard across all EKS 

