### PR TITLE
fix: only setup LB discovery subnet tags for in-use AZ 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -303,6 +303,7 @@ module "vpc_tags" {
   vpc_id             = var.vpc_id
   public_subnet_ids  = var.public_subnet_ids
   private_subnet_ids = var.private_subnet_ids
+  node_pool_azs      = var.node_pool_azs
 }
 
 resource "aws_ec2_tag" "cluster_security_group" {

--- a/modules/eks-vpc-tags/main.tf
+++ b/modules/eks-vpc-tags/main.tf
@@ -25,12 +25,10 @@ data "aws_subnet" "public_subnets" {
 locals {
   cluster_subnet_ids = concat(var.private_subnet_ids, var.public_subnet_ids)
   node_pool_private_subnets = [
-    for subnet in data.aws_subnet.private_subnets : subnet.id 
-    if length(var.node_pool_azs) != 0 ? contains(var.node_pool_azs, subnet.availability_zone) : true
+    for subnet in data.aws_subnet.private_subnets : subnet.id if(length(var.node_pool_azs) == 0 || contains(var.node_pool_azs, subnet.availability_zone))
   ]
   node_pool_public_subnets = [
-    for subnet in data.aws_subnet.public_subnets : subnet.id 
-    if length(var.node_pool_azs) != 0 ? contains(var.node_pool_azs, subnet.availability_zone) : true
+    for subnet in data.aws_subnet.public_subnets : subnet.id if(length(var.node_pool_azs) == 0 || contains(var.node_pool_azs, subnet.availability_zone))
   ]
 }
 

--- a/modules/eks-vpc-tags/variables.tf
+++ b/modules/eks-vpc-tags/variables.tf
@@ -57,3 +57,9 @@ variable "vpc_id" {
     error_message = "The value for variable \"vpc_id\" must be a valid VPC id, starting with \"vpc-\"."
   }
 }
+
+variable "node_pool_azs" {
+  type        = list(string)
+  description = "A list of availability zones to use for the EKS node group. If not set, the module will use the same availability zones with the cluster."
+  default     = []
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -39,7 +39,7 @@ resource "aws_subnet" "public" {
   cidr_block              = cidrsubnet(var.vpc_cidr, var.public_subnet_newbits, var.public_subnet_start + count.index)
   availability_zone       = local.azs[count.index]
   map_public_ip_on_launch = var.disable_nat_gateway ? true : var.public_subnet_auto_ip
-  tags                    = merge({ "Vendor" = "StreamNative", "Type" = "public", "kubernetes.io/role/elb" = "1", Name = format("%s-public-sbn-%s", var.vpc_name, count.index) }, var.tags)
+  tags                    = merge({ "Vendor" = "StreamNative", "Type" = "public", Name = format("%s-public-sbn-%s", var.vpc_name, count.index) }, var.tags)
 
   lifecycle {
     ignore_changes = [tags]
@@ -52,7 +52,7 @@ resource "aws_subnet" "private" {
   vpc_id            = aws_vpc.vpc.id
   cidr_block        = cidrsubnet(var.vpc_cidr, var.private_subnet_newbits, var.private_subnet_start + count.index)
   availability_zone = local.azs[count.index]
-  tags              = merge({ "Vendor" = "StreamNative", "Type" = "private", "kubernetes.io/role/internal-elb" = "1", Name = format("%s-private-sbn-%s", var.vpc_name, count.index) }, var.tags)
+  tags              = merge({ "Vendor" = "StreamNative", "Type" = "private", Name = format("%s-private-sbn-%s", var.vpc_name, count.index) }, var.tags)
 
   lifecycle {
     ignore_changes = [tags]


### PR DESCRIPTION
<!--
  ~ Copyright 2023 StreamNative, Inc.
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation
- Avoid unnecessary inter-zone traffic from LB
- Allow disabling cross-zone load balancing when specifying zones

### Modifications
- Remove duplicated tag setup in VPC module
- Only setup LB discovery tags for subnet will be used by nodepool

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

