### PR TITLE
fix: restrict cluster iam role name prefix length

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -253,7 +253,7 @@ module "eks" {
   iam_role_arn                  = try(var.cluster_iam.iam_role_arn, aws_iam_role.cluster[0].arn, null)
   create_iam_role               = try(var.cluster_iam.create_iam_role, true)
   iam_role_use_name_prefix      = try(var.cluster_iam.iam_role_use_name_prefix, true)
-  iam_role_name                 = try(var.cluster_iam.iam_role_name, null)
+  iam_role_name                 = try(var.cluster_iam.iam_role_name, substr("${var.cluster_name}-cluster", 0, 37), null)
   iam_role_path                 = try(var.cluster_iam.iam_role_path, var.iam_path, "/StreamNative/")
   iam_role_permissions_boundary = try(var.cluster_iam.iam_role_permissions_boundary, var.permissions_boundary_arn, null)
 


### PR DESCRIPTION
<!--
  ~ Copyright 2023 StreamNative, Inc.
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

IAM Role name length is between 1 and 64.

The IAM Role name_prefix length is between 1 and 38. Because the suffix length is 26 which is defined [in the terraform provider](https://github.com/hashicorp/terraform-plugin-sdk/blob/d829d8ebe2cffabeeb7e65204a060619d25b0159/helper/id/id.go#L27).

### Modifications

- Restrict `${var.cluster_name}-cluster` to 37, since the separator `-` is 1

### Verifying this change

- For new cluster
- For existing cluster

### Documentation

- [x] `no-need-doc` 
  
