### PR TITLE
fix(vpc): region regex validation

### DIFF
--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -86,7 +86,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | n/a |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | A list of private subnet ID's created by this module |
+| <a name="output_public_route_table_ids"></a> [public\_route\_table\_ids](#output\_public\_route\_table\_ids) | n/a |
 | <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | A list of public subnet ID's created by this module |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC created by this module |
 <!-- END_TF_DOCS -->

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -15,7 +15,7 @@
 variable "region" {
   type = string
   validation {
-    condition     = can(regex("^(us|af|ap|ca|eu|me|sa|cn)\\-(east|west|south|northeast|southeast|central|north|northwest)\\-(1|2|3)$", var.region))
+    condition     = can(regex("^(us|af|ap|ca|eu|il|mx|me|sa|cn)\\-(east|west|south|northeast|southeast|central|north|northwest)\\-\\d$", var.region))
     error_message = "The region must be a proper AWS region."
   }
 }


### PR DESCRIPTION
<!--
  ~ Copyright 2023 StreamNative, Inc.
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

According to the latest [AWS Regions](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html), we need to support more regions.

### Modifications

- Using `\d` to match the last digit of AWS region, and add missing first part

### Verifying this change

Verifed locally

```hcl
module "vpc" {
  source = "../../modules/vpc"

  region = "ap-southeast-5"

  vpc_cidr = "10.16.0.0/16"
  vpc_name = "test"
}
```

### Documentation

- [x] `doc` 
  
  (If this PR contains doc changes)

