### PR TITLE
feat: add iam submodule for managing applications iam

### DIFF
--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -1,0 +1,97 @@
+!--
+  ~ Copyright 2025 StreamNative, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+-->
+
+# IAM Module
+A basic module used to create IAM Roles, Policies for StreamNative Cloud Applications.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64.2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.velero](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.csi_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.external_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.velero](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.aws_load_balancer_controller_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cert_manager_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cluster_autoscaler_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.csi_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.external_dns_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.karpenter_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.velero_sts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_backup_bucket"></a> [backup\_bucket](#input\_backup\_bucket) | The name of the s3 bucket to use for backups | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
+| <a name="input_cluster_node_group_iam_role_arn"></a> [cluster\_node\_group\_iam\_role\_arn](#input\_cluster\_node\_group\_iam\_role\_arn) | n/a | `string` | n/a | yes |
+| <a name="input_enable_karpenter"></a> [enable\_karpenter](#input\_enable\_karpenter) | Enable karpenter for autoscaling. If set to false, no karpenter resources will be created. | `bool` | `false` | no |
+| <a name="input_enable_velero"></a> [enable\_velero](#input\_enable\_velero) | Enable velero for backups. If set to false, no velero resources will be created. | `bool` | `true` | no |
+| <a name="input_extra_aws_tags"></a> [extra\_aws\_tags](#input\_extra\_aws\_tags) | extra aws tags to add to any resources | `map(string)` | `{}` | no |
+| <a name="input_load_balancer_policy_arn_override"></a> [load\_balancer\_policy\_arn\_override](#input\_load\_balancer\_policy\_arn\_override) | Override the runtime policy arn, otherwise will construct an arn | `string` | `""` | no |
+| <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | The oidc issuer for the cluster | `string` | n/a | yes |
+| <a name="input_permissions_boundary_arn_override"></a> [permissions\_boundary\_arn\_override](#input\_permissions\_boundary\_arn\_override) | Override the permission boundary arn, otherwise will construct an arn | `string` | `""` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_runtime_policy_arn_override"></a> [runtime\_policy\_arn\_override](#input\_runtime\_policy\_arn\_override) | Override the runtime policy arn, otherwise will construct an arn | `string` | `""` | no |
+| <a name="input_s3_encryption_kms_key_arn"></a> [s3\_encryption\_kms\_key\_arn](#input\_s3\_encryption\_kms\_key\_arn) | KMS key ARN to use for S3 encryption. If not set, the default AWS S3 key will be used. | `string` | `""` | no |
+| <a name="input_velero_backup_schedule"></a> [velero\_backup\_schedule](#input\_velero\_backup\_schedule) | The scheduled time for Velero to perform backups. Written in cron expression, defaults to "0 5 * * *" or "at 5:00am every day" | `string` | `"0 5 * * *"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_load_balancer_controller_arn"></a> [aws\_load\_balancer\_controller\_arn](#output\_aws\_load\_balancer\_controller\_arn) | n/a |
+| <a name="output_cert_manager_arn"></a> [cert\_manager\_arn](#output\_cert\_manager\_arn) | n/a |
+| <a name="output_cluster_autoscaler_arn"></a> [cluster\_autoscaler\_arn](#output\_cluster\_autoscaler\_arn) | n/a |
+| <a name="output_csi_arn"></a> [csi\_arn](#output\_csi\_arn) | n/a |
+| <a name="output_external_dns_arn"></a> [external\_dns\_arn](#output\_external\_dns\_arn) | n/a |
+| <a name="output_karpenter_arn"></a> [karpenter\_arn](#output\_karpenter\_arn) | n/a |
+| <a name="output_velero_arn"></a> [velero\_arn](#output\_velero\_arn) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/iam/aws_load_balancer_controller.tf
+++ b/modules/iam/aws_load_balancer_controller.tf
@@ -1,0 +1,31 @@
+data "aws_iam_policy_document" "aws_load_balancer_controller_sts" {
+  statement {
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [format("arn:%s:iam::%s:oidc-provider/%s", local.aws_partition, local.account_id, local.oidc_issuer)]
+    }
+    condition {
+      test     = "StringLike"
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "aws-load-balancer-controller")]
+      variable = format("%s:sub", local.oidc_issuer)
+    }
+  }
+}
+
+resource "aws_iam_role" "aws_load_balancer_controller" {
+  name                 = format("%s-lbc-role", var.cluster_name)
+  description          = format("Role used by IRSA and the KSA aws-load-balancer-controller on StreamNative Cloud EKS cluster %s", var.cluster_name)
+  assume_role_policy   = data.aws_iam_policy_document.aws_load_balancer_controller_sts.json
+  path                 = "/StreamNative/"
+  permissions_boundary = local.permissions_boundary_arn
+  tags                 = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller" {
+  role       = aws_iam_role.aws_load_balancer_controller.name
+  policy_arn = local.default_lb_policy_arn
+}

--- a/modules/iam/cert_manager.tf
+++ b/modules/iam/cert_manager.tf
@@ -1,0 +1,31 @@
+data "aws_iam_policy_document" "cert_manager_sts" {
+  statement {
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [format("arn:%s:iam::%s:oidc-provider/%s", local.aws_partition, local.account_id, local.oidc_issuer)]
+    }
+    condition {
+      test     = "StringLike"
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "cert-manager-controller")]
+      variable = format("%s:sub", local.oidc_issuer)
+    }
+  }
+}
+
+resource "aws_iam_role" "cert_manager" {
+  name                 = format("%s-cm-role", var.cluster_name)
+  description          = format("Role assumed by IRSA and the KSA cert-manager on StreamNative Cloud EKS cluster %s", var.cluster_name)
+  assume_role_policy   = data.aws_iam_policy_document.cert_manager_sts.json
+  path                 = "/StreamNative/"
+  permissions_boundary = local.permissions_boundary_arn
+  tags                 = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cert_manager" {
+  role       = aws_iam_role.cert_manager.name
+  policy_arn = local.default_service_policy_arn
+}

--- a/modules/iam/cluster_autoscaler.tf
+++ b/modules/iam/cluster_autoscaler.tf
@@ -1,0 +1,42 @@
+data "aws_iam_policy_document" "cluster_autoscaler_sts" {
+  count = var.enable_karpenter ? 1 : 0
+
+  statement {
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [format("arn:%s:iam::%s:oidc-provider/%s", local.aws_partition, local.account_id, local.oidc_issuer)]
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "cluster-autoscaler")]
+      variable = format("%s:sub", local.oidc_issuer)
+    }
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = format("%s:aud", local.oidc_issuer)
+    }
+  }
+}
+
+resource "aws_iam_role" "cluster_autoscaler" {
+  count = var.enable_karpenter ? 1 : 0
+
+  name                 = format("%s-ca-role", var.cluster_name)
+  description          = format("Role used by IRSA and the KSA cluster-autoscaler on StreamNative Cloud EKS cluster %s", var.cluster_name)
+  assume_role_policy   = data.aws_iam_policy_document.cluster_autoscaler_sts.0.json
+  path                 = "/StreamNative/"
+  permissions_boundary = local.permissions_boundary_arn
+  tags                 = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
+  count = var.enable_karpenter ? 1 : 0
+
+  policy_arn = local.default_service_policy_arn
+  role       = aws_iam_role.cluster_autoscaler.0.name
+}

--- a/modules/iam/csi.tf
+++ b/modules/iam/csi.tf
@@ -1,0 +1,41 @@
+data "aws_iam_policy_document" "csi_sts" {
+  statement {
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [format("arn:%s:iam::%s:oidc-provider/%s", local.aws_partition, local.account_id, local.oidc_issuer)]
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "ebs-csi-controller-sa")]
+      variable = format("%s:sub", local.oidc_issuer)
+    }
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = format("%s:aud", local.oidc_issuer)
+    }
+  }
+}
+
+resource "aws_iam_role" "csi" {
+  name                 = format("%s-csi-role", var.cluster_name)
+  description          = format("Role used by IRSA and the KSA ebs-csi-controller-sa on StreamNative Cloud EKS cluster %s", var.cluster_name)
+  assume_role_policy   = data.aws_iam_policy_document.csi_sts.json
+  path                 = "/StreamNative/"
+  permissions_boundary = local.permissions_boundary_arn
+  tags                 = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "csi" {
+  role       = aws_iam_role.csi.name
+  policy_arn = local.default_service_policy_arn
+}
+
+resource "aws_iam_role_policy_attachment" "csi_managed" {
+  role       = aws_iam_role.csi.name
+  policy_arn = "arn:${local.aws_partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}

--- a/modules/iam/external_dns.tf
+++ b/modules/iam/external_dns.tf
@@ -1,0 +1,31 @@
+data "aws_iam_policy_document" "external_dns_sts" {
+  statement {
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [format("arn:%s:iam::%s:oidc-provider/%s", local.aws_partition, local.account_id, local.oidc_issuer)]
+    }
+    condition {
+      test     = "StringLike"
+      values   = [format("system:serviceaccount:%s:%s", "kube-system", "external-dns")]
+      variable = format("%s:sub", local.oidc_issuer)
+    }
+  }
+}
+
+resource "aws_iam_role" "external_dns" {
+  name                 = format("%s-extdns-role", var.cluster_name)
+  description          = format("Role used by IRSA and the KSA external-dns on StreamNative Cloud EKS cluster %s", var.cluster_name)
+  assume_role_policy   = data.aws_iam_policy_document.external_dns_sts.json
+  path                 = "/StreamNative/"
+  permissions_boundary = local.permissions_boundary_arn
+  tags                 = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "external_dns" {
+  role       = aws_iam_role.external_dns.name
+  policy_arn = local.default_service_policy_arn
+}

--- a/modules/iam/karpenter.tf
+++ b/modules/iam/karpenter.tf
@@ -1,0 +1,399 @@
+data "aws_iam_policy_document" "karpenter_sts" {
+  count = var.enable_karpenter ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    principals {
+      type        = "Federated"
+      identifiers = [format("arn:%s:iam::%s:oidc-provider/%s", local.aws_partition, local.account_id, local.oidc_issuer)]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = format("%s:sub", local.oidc_issuer)
+      values   = ["system:serviceaccount:kube-system:karpenter"]
+    }
+
+    # https://aws.amazon.com/premiumsupport/knowledge-center/eks-troubleshoot-oidc-and-irsa/?nc1=h_ls
+    condition {
+      test     = "StringEquals"
+      variable = format("%s:aud", local.oidc_issuer)
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "karpenter" {
+  count = var.enable_karpenter ? 1 : 0
+
+  name                  = format("%s-karpenter", var.cluster_name)
+  path                  = "/StreamNative/"
+  description           = format("Karpenter controller IAM role on StreamNative Cloud EKS cluster %s", var.cluster_name)
+  assume_role_policy    = data.aws_iam_policy_document.karpenter_sts[0].json
+  permissions_boundary  = local.permissions_boundary_arn
+  force_detach_policies = true
+  tags                  = local.tags
+}
+
+data "aws_iam_policy_document" "karpenter" {
+  count = var.enable_karpenter ? 1 : 0
+
+  statement {
+    sid = "AllowScopedEC2InstanceAccessActions"
+    resources = [
+      "arn:${local.aws_partition}:ec2:${var.region}::image/*",
+      "arn:${local.aws_partition}:ec2:${var.region}::snapshot/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:security-group/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:subnet/*",
+    ]
+
+    actions = [
+      "ec2:RunInstances",
+      "ec2:CreateFleet"
+    ]
+  }
+
+  statement {
+    sid = "AllowScopedEC2LaunchTemplateAccessActions"
+    resources = [
+      "arn:${local.aws_partition}:ec2:${var.region}:*:launch-template/*"
+    ]
+
+    actions = [
+      "ec2:RunInstances",
+      "ec2:CreateFleet"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/karpenter.sh/nodepool"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    sid = "AllowScopedEC2InstanceActionsWithTags"
+    resources = [
+      "arn:${local.aws_partition}:ec2:${var.region}:*:fleet/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:instance/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:volume/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:network-interface/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:launch-template/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:spot-instances-request/*",
+    ]
+    actions = [
+      "ec2:RunInstances",
+      "ec2:CreateFleet",
+      "ec2:CreateLaunchTemplate"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/karpenter.sh/nodepool"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    sid = "AllowScopedResourceCreationTagging"
+    resources = [
+      "arn:${local.aws_partition}:ec2:${var.region}:*:fleet/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:instance/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:volume/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:network-interface/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:launch-template/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:spot-instances-request/*",
+    ]
+    actions = ["ec2:CreateTags"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values = [
+        "RunInstances",
+        "CreateFleet",
+        "CreateLaunchTemplate",
+      ]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/karpenter.sh/nodepool"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    sid       = "AllowScopedResourceTagging"
+    resources = ["arn:${local.aws_partition}:ec2:${var.region}:*:instance/*"]
+    actions   = ["ec2:CreateTags"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/karpenter.sh/nodepool"
+      values   = ["*"]
+    }
+
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "aws:TagKeys"
+      values = [
+        "eks:eks-cluster-name",
+        "karpenter.sh/nodeclaim",
+        "Name",
+      ]
+    }
+  }
+
+  statement {
+    sid = "AllowScopedDeletion"
+    resources = [
+      "arn:${local.aws_partition}:ec2:${var.region}:*:instance/*",
+      "arn:${local.aws_partition}:ec2:${var.region}:*:launch-template/*"
+    ]
+
+    actions = [
+      "ec2:TerminateInstances",
+      "ec2:DeleteLaunchTemplate"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/karpenter.sh/nodepool"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    sid       = "AllowRegionalReadActions"
+    resources = ["*"]
+    actions = [
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypeOfferings",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeLaunchTemplates",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSpotPriceHistory",
+      "ec2:DescribeSubnets"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = [var.region]
+    }
+  }
+
+  statement {
+    sid       = "AllowSSMReadActions"
+    resources = ["arn:${local.aws_partition}:ssm:${var.region}::parameter/aws/service/*"]
+    actions   = ["ssm:GetParameter"]
+  }
+
+  statement {
+    sid       = "AllowPricingReadActions"
+    resources = ["*"]
+    actions   = ["pricing:GetProducts"]
+  }
+
+  statement {
+    sid       = "AllowInterruptionQueueActions"
+    resources = ["*"]
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:GetQueueUrl",
+      "sqs:ReceiveMessage"
+    ]
+  }
+
+  statement {
+    sid       = "AllowPassingInstanceRole"
+    resources = [var.cluster_node_group_iam_role_arn]
+    actions   = ["iam:PassRole"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ec2.${local.dns_suffix}"]
+    }
+  }
+
+  statement {
+    sid       = "AllowScopedInstanceProfileCreationActions"
+    resources = ["arn:${local.aws_partition}:iam::${local.account_id}:instance-profile/*"]
+    actions   = ["iam:CreateInstanceProfile"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/topology.kubernetes.io/region"
+      values   = [var.region]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    sid       = "AllowScopedInstanceProfileTagActions"
+    resources = ["arn:${local.aws_partition}:iam::${local.account_id}:instance-profile/*"]
+    actions   = ["iam:TagInstanceProfile"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/topology.kubernetes.io/region"
+      values   = [var.region]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/topology.kubernetes.io/region"
+      values   = [var.region]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass"
+      values   = ["*"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/karpenter.k8s.aws/ec2nodeclass"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    sid       = "AllowScopedInstanceProfileActions"
+    resources = ["arn:${local.aws_partition}:iam::${local.account_id}:instance-profile/*"]
+    actions = [
+      "iam:AddRoleToInstanceProfile",
+      "iam:RemoveRoleFromInstanceProfile",
+      "iam:DeleteInstanceProfile"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/topology.kubernetes.io/region"
+      values   = [var.region]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    sid       = "AllowInstanceProfileReadActions"
+    resources = ["arn:${local.aws_partition}:iam::${local.account_id}:instance-profile/*"]
+    actions   = ["iam:GetInstanceProfile"]
+  }
+
+  statement {
+    sid       = "AllowAPIServerEndpointDiscovery"
+    resources = ["arn:${local.aws_partition}:eks:${var.region}:${local.account_id}:cluster/${var.cluster_name}"]
+    actions   = ["eks:DescribeCluster"]
+  }
+}
+
+resource "aws_iam_role_policy" "karpenter" {
+  count = var.enable_karpenter ? 1 : 0
+
+  name_prefix = "KarpenterController"
+  role        = aws_iam_role.karpenter[0].name
+  policy      = data.aws_iam_policy_document.karpenter[0].json
+}

--- a/modules/iam/locals.tf
+++ b/modules/iam/locals.tf
@@ -1,0 +1,19 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+locals {
+  account_id    = data.aws_caller_identity.current.account_id
+  aws_partition = data.aws_partition.current.partition
+  dns_suffix    = data.aws_partition.current.dns_suffix
+  oidc_issuer   = var.oidc_issuer
+
+  permissions_boundary_arn   = var.permissions_boundary_arn_override != "" ? var.permissions_boundary_arn_override : "arn:${local.aws_partition}:iam::${local.account_id}:policy/StreamNative/StreamNativeCloudPermissionBoundary"
+  default_service_policy_arn = var.runtime_policy_arn_override != "" ? var.runtime_policy_arn_override : "arn:${local.aws_partition}:iam::${local.account_id}:policy/StreamNative/StreamNativeCloudRuntimePolicy"
+  default_lb_policy_arn      = var.load_balancer_policy_arn_override != "" ? var.load_balancer_policy_arn_override : "arn:${local.aws_partition}:iam::${local.account_id}:policy/StreamNative/StreamNativeCloudLBPolicy"
+
+  tags = merge({
+    "Vendor"       = "StreamNative"
+    "cluster-name" = var.cluster_name
+  }, var.extra_aws_tags)
+}

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -1,0 +1,27 @@
+output "aws_load_balancer_controller_arn" {
+  value = aws_iam_role.aws_load_balancer_controller.arn
+}
+
+output "cert_manager_arn" {
+  value = aws_iam_role.cert_manager.arn
+}
+
+output "cluster_autoscaler_arn" {
+  value = aws_iam_role.cluster_autoscaler.0.arn
+}
+
+output "csi_arn" {
+  value = aws_iam_role.csi.arn
+}
+
+output "external_dns_arn" {
+  value = aws_iam_role.external_dns.arn
+}
+
+output "karpenter_arn" {
+  value = aws_iam_role.karpenter.0.arn
+}
+
+output "velero_arn" {
+  value = aws_iam_role.velero.0.arn
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -1,0 +1,72 @@
+variable "region" {
+  description = "AWS Region"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "The name of the cluster"
+  type        = string
+}
+
+variable "oidc_issuer" {
+  description = "The oidc issuer for the cluster"
+  type        = string
+}
+
+variable "permissions_boundary_arn_override" {
+  default     = ""
+  description = "Override the permission boundary arn, otherwise will construct an arn"
+  type        = string
+}
+
+variable "runtime_policy_arn_override" {
+  default     = ""
+  description = "Override the runtime policy arn, otherwise will construct an arn"
+  type        = string
+}
+
+variable "load_balancer_policy_arn_override" {
+  default     = ""
+  description = "Override the runtime policy arn, otherwise will construct an arn"
+  type        = string
+}
+
+variable "enable_karpenter" {
+  type        = bool
+  default     = false
+  description = "Enable karpenter for autoscaling. If set to false, no karpenter resources will be created."
+}
+
+variable "cluster_node_group_iam_role_arn" {
+  type = string
+}
+
+variable "enable_velero" {
+  type        = bool
+  default     = true
+  description = "Enable velero for backups. If set to false, no velero resources will be created."
+}
+
+variable "s3_encryption_kms_key_arn" {
+  default     = ""
+  description = "KMS key ARN to use for S3 encryption. If not set, the default AWS S3 key will be used."
+  type        = string
+}
+
+variable "backup_bucket" {
+  description = "The name of the s3 bucket to use for backups"
+  type        = string
+}
+
+variable "velero_backup_schedule" {
+  default     = "0 5 * * *"
+  description = "The scheduled time for Velero to perform backups. Written in cron expression, defaults to \"0 5 * * *\" or \"at 5:00am every day\""
+  type        = string
+}
+
+
+variable "extra_aws_tags" {
+  default     = {}
+  description = "extra aws tags to add to any resources"
+  type        = map(string)
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -47,24 +47,6 @@ variable "enable_velero" {
   description = "Enable velero for backups. If set to false, no velero resources will be created."
 }
 
-variable "s3_encryption_kms_key_arn" {
-  default     = ""
-  description = "KMS key ARN to use for S3 encryption. If not set, the default AWS S3 key will be used."
-  type        = string
-}
-
-variable "backup_bucket" {
-  description = "The name of the s3 bucket to use for backups"
-  type        = string
-}
-
-variable "velero_backup_schedule" {
-  default     = "0 5 * * *"
-  description = "The scheduled time for Velero to perform backups. Written in cron expression, defaults to \"0 5 * * *\" or \"at 5:00am every day\""
-  type        = string
-}
-
-
 variable "extra_aws_tags" {
   default     = {}
   description = "extra aws tags to add to any resources"

--- a/modules/iam/velero.tf
+++ b/modules/iam/velero.tf
@@ -1,0 +1,37 @@
+data "aws_iam_policy_document" "velero_sts" {
+  count = var.enable_velero ? 1 : 0
+
+  statement {
+    actions = [
+      "sts:AssumeRoleWithWebIdentity"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [format("arn:%s:iam::%s:oidc-provider/%s", local.aws_partition, local.account_id, local.oidc_issuer)]
+    }
+    condition {
+      test     = "StringLike"
+      values   = [format("system:serviceaccount:%s:%s", "velero", "velero")]
+      variable = format("%s:sub", local.oidc_issuer)
+    }
+  }
+}
+
+resource "aws_iam_role" "velero" {
+  count = var.enable_velero ? 1 : 0
+
+  name                 = format("%s-velero-backup-role", var.cluster_name)
+  description          = format("Role used by IRSA and the KSA velero on StreamNative Cloud EKS cluster %s", var.cluster_name)
+  assume_role_policy   = data.aws_iam_policy_document.velero_sts.0.json
+  tags                 = local.tags
+  path                 = "/StreamNative/"
+  permissions_boundary = local.permissions_boundary_arn
+}
+
+resource "aws_iam_role_policy_attachment" "velero" {
+  count = var.enable_velero ? 1 : 0
+
+  role       = aws_iam_role.velero.0.name
+  policy_arn = local.default_service_policy_arn
+}

--- a/modules/iam/versions.tf
+++ b/modules/iam/versions.tf
@@ -1,0 +1,25 @@
+# Copyright 2025 StreamNative, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">=1.2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.64.2"
+    }
+  }
+}
+


### PR DESCRIPTION
<!--
  ~ Copyright 2023 StreamNative, Inc.
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
  ~ you may not use this file except in compliance with the License.
  ~ You may obtain a copy of the License at
  ~
  ~     http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
-->

<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

Provide a unified iam module to managing all the IAM roles, policies required by StreamNative Cloud Infra applications.

### Modifications

- `aws_load_balancer_controller_arn`
- `cert_manager_arn`
- `cluster_autoscaler_arn`
- `csi_arn`
- `external_dns_arn`
- `karpenter_arn`
- `velero_arn`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

- [x] `doc` 
  