### PR TITLE
feat: allow overriding S3 bucket names in dns-bucket module

### DIFF
--- a/modules/dns-bucket/README.md
+++ b/modules/dns-bucket/README.md
@@ -21,13 +21,13 @@ A basic module used to create Route53 Zone and S3 Buckets.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.2.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.76.0 |
 | <a name="provider_aws.source"></a> [aws.source](#provider\_aws.source) | 5.76.0 |
 | <a name="provider_aws.target"></a> [aws.target](#provider\_aws.target) | 5.76.0 |
@@ -39,7 +39,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_route53_record.delegate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.loki](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
@@ -52,21 +52,24 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_custom_dns_zone_id"></a> [custom\_dns\_zone\_id](#input\_custom\_dns\_zone\_id) | if specified, then a streamnative zone will not be created, and this zone will be used instead. Otherwise, we will provision a new zone and delegate access | `string` | `""` | no |
 | <a name="input_custom_dns_zone_name"></a> [custom\_dns\_zone\_name](#input\_custom\_dns\_zone\_name) | must be passed if custom\_dns\_zone\_id is passed, this is the zone name to use | `string` | `""` | no |
 | <a name="input_enable_loki"></a> [enable\_loki](#input\_enable\_loki) | Enable loki storage bucket creation | `bool` | `false` | no |
 | <a name="input_enable_velero"></a> [enable\_velero](#input\_enable\_velero) | Enable velero for backups. If set to false, no velero resources will be created. | `bool` | `false` | no |
 | <a name="input_extra_aws_tags"></a> [extra\_aws\_tags](#input\_extra\_aws\_tags) | Additional to apply to the resources. Note that this module sets the tags Name, Type, and Vendor by default. They can be overwritten, but it is not recommended. | `map(string)` | `{}` | no |
+| <a name="input_loki_bucket_name"></a> [loki\_bucket\_name](#input\_loki\_bucket\_name) | Override the generated name if specified | `string` | `""` | no |
 | <a name="input_parent_zone_name"></a> [parent\_zone\_name](#input\_parent\_zone\_name) | The parent zone in which we create the delegation records | `string` | n/a | yes |
 | <a name="input_pm_name"></a> [pm\_name](#input\_pm\_name) | The name of the poolmember, for new clusters, this should be like `pm-<xxxxx>` | `string` | n/a | yes |
 | <a name="input_pm_namespace"></a> [pm\_namespace](#input\_pm\_namespace) | The namespace of the poolmember | `string` | n/a | yes |
 | <a name="input_s3_encryption_kms_key_arn"></a> [s3\_encryption\_kms\_key\_arn](#input\_s3\_encryption\_kms\_key\_arn) | KMS key ARN to use for S3 encryption. If not set, the default AWS S3 key will be used. | `string` | `""` | no |
+| <a name="input_tiered_storage_bucket_name"></a> [tiered\_storage\_bucket\_name](#input\_tiered\_storage\_bucket\_name) | Override the generated name if specified | `string` | `""` | no |
+| <a name="input_velero_bucket_name"></a> [velero\_bucket\_name](#input\_velero\_bucket\_name) | Override the generated name if specified | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_backup_bucket"></a> [backup\_bucket](#output\_backup\_bucket) | n/a |
 | <a name="output_backup_bucket_kms_key_id"></a> [backup\_bucket\_kms\_key\_id](#output\_backup\_bucket\_kms\_key\_id) | n/a |
 | <a name="output_loki_bucket"></a> [loki\_bucket](#output\_loki\_bucket) | n/a |

--- a/modules/dns-bucket/bucket.tf
+++ b/modules/dns-bucket/bucket.tf
@@ -15,14 +15,14 @@
 resource "aws_s3_bucket" "velero" {
   count         = var.enable_velero ? 1 : 0
   provider      = aws.target
-  bucket        = format("%s-cluster-backup-snc", var.pm_name)
+  bucket        = coalesce(var.velero_bucket_name, format("%s-cluster-backup-snc", var.pm_name))
   tags          = merge({ "Attributes" = "backup", "Name" = "velero-backups" }, local.tags)
   force_destroy = true
 }
 
 resource "aws_s3_bucket" "tiered_storage" {
   provider      = aws.target
-  bucket        = format("%s-tiered-storage-snc", var.pm_name)
+  bucket        = coalesce(var.tiered_storage_bucket_name, format("%s-tiered-storage-snc", var.pm_name))
   tags          = merge({ "Attributes" = "tiered-storage" }, local.tags)
   force_destroy = true
 }
@@ -30,7 +30,7 @@ resource "aws_s3_bucket" "tiered_storage" {
 resource "aws_s3_bucket" "loki" {
   count         = var.enable_loki ? 1 : 0
   provider      = aws.source
-  bucket        = format("loki-%s-%s", var.pm_namespace, var.pm_name)
+  bucket        = coalesce(var.loki_bucket_name, format("loki-%s-%s", var.pm_namespace, var.pm_name))
   tags          = merge({ "Attributes" = "loki" }, local.tags)
   force_destroy = true
 }

--- a/modules/dns-bucket/variables.tf
+++ b/modules/dns-bucket/variables.tf
@@ -68,3 +68,21 @@ variable "enable_velero" {
   default     = false
   description = "Enable velero for backups. If set to false, no velero resources will be created."
 }
+
+variable "velero_bucket_name" {
+  type        = string
+  default     = ""
+  description = "Override the generated name if specified"
+}
+
+variable "tiered_storage_bucket_name" {
+  type        = string
+  default     = ""
+  description = "Override the generated name if specified"
+}
+
+variable "loki_bucket_name" {
+  type        = string
+  default     = ""
+  description = "Override the generated name if specified"
+}


### PR DESCRIPTION

### Motivation

Currently, S3 bucket names in the `dns-bucket` module are automatically generated based on the `pm_name` and `pm_namespace`. There are cases where users might want to use custom bucket names or match existing buckets. This change introduces override variables for Velero, Tiered Storage, and Loki buckets.

### Modifications

- Added `velero_bucket_name`, `tiered_storage_bucket_name`, and `loki_bucket_name` variables to `modules/dns-bucket/variables.tf`.
- Updated `aws_s3_bucket` resources in `modules/dns-bucket/bucket.tf` to use `coalesce` with these new variables, defaulting to the existing generated names if the overrides are not provided.
- Updated `modules/dns-bucket/README.md` using `terraform-docs`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework allowing for more flexibility in naming.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
- [x] `no-need-doc` 
  
  Variables are self-documented in Terraform and README has been updated.
