### PR TITLE
feat: Migrate to a standard name for adding extra tags

### DIFF
--- a/modules/dns-bucket/variables.tf
+++ b/modules/dns-bucket/variables.tf
@@ -47,14 +47,20 @@ variable "s3_encryption_kms_key_arn" {
 
 variable "extra_aws_tags" {
   default     = {}
-  description = "Additional to apply to the resources. Note that this module sets the tags Name, Type, and Vendor by default. They can be overwritten, but it is not recommended."
+  description = "Deprecated: use additional_tags instead."
+  type        = map(string)
+}
+
+variable "additional_tags" {
+  default     = {}
+  description = "Additional tags to apply to the resources. Note that this module sets the tags Name, Type, and Vendor by default. They can be overwritten, but it is not recommended."
   type        = map(string)
 }
 
 locals {
   tags = merge({
     "Vendor" = "StreamNative"
-  }, var.extra_aws_tags)
+  }, var.extra_aws_tags, var.additional_tags)
 }
 
 variable "enable_loki" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -19,13 +19,14 @@ data "aws_availability_zones" "available" {
 locals {
   azs     = length(var.availability_zones) > 0 ? var.availability_zones : data.aws_availability_zones.available.names
   num_azs = length(var.availability_zones) > 0 ? length(var.availability_zones) : var.num_azs
+  tags = merge(var.tags, var.additional_tags)
 }
 
 resource "aws_vpc" "vpc" {
   cidr_block           = var.vpc_cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
-  tags                 = merge({ "Vendor" = "StreamNative", Name = format("%s-vpc", var.vpc_name) }, var.tags)
+  tags                 = merge({ "Vendor" = "StreamNative", Name = format("%s-vpc", var.vpc_name) }, local.tags)
 
   lifecycle {
     ignore_changes = [tags]
@@ -39,7 +40,7 @@ resource "aws_subnet" "public" {
   cidr_block              = cidrsubnet(var.vpc_cidr, var.public_subnet_newbits, var.public_subnet_start + count.index)
   availability_zone       = local.azs[count.index]
   map_public_ip_on_launch = var.disable_nat_gateway ? true : var.public_subnet_auto_ip
-  tags                    = merge({ "Vendor" = "StreamNative", "Type" = "public", Name = format("%s-public-sbn-%s", var.vpc_name, count.index) }, var.tags)
+  tags                    = merge({ "Vendor" = "StreamNative", "Type" = "public", Name = format("%s-public-sbn-%s", var.vpc_name, count.index) }, local.tags)
 
   lifecycle {
     ignore_changes = [tags]
@@ -52,7 +53,7 @@ resource "aws_subnet" "private" {
   vpc_id            = aws_vpc.vpc.id
   cidr_block        = cidrsubnet(var.vpc_cidr, var.private_subnet_newbits, var.private_subnet_start + count.index)
   availability_zone = local.azs[count.index]
-  tags              = merge({ "Vendor" = "StreamNative", "Type" = "private", Name = format("%s-private-sbn-%s", var.vpc_name, count.index) }, var.tags)
+  tags              = merge({ "Vendor" = "StreamNative", "Type" = "private", Name = format("%s-private-sbn-%s", var.vpc_name, count.index) }, local.tags)
 
   lifecycle {
     ignore_changes = [tags]
@@ -61,7 +62,7 @@ resource "aws_subnet" "private" {
 
 resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.vpc.id
-  tags   = merge({ "Vendor" = "StreamNative", Name = format("%s-igw", var.vpc_name) }, var.tags)
+  tags   = merge({ "Vendor" = "StreamNative", Name = format("%s-igw", var.vpc_name) }, local.tags)
 
   lifecycle {
     ignore_changes = [tags]
@@ -72,7 +73,7 @@ resource "aws_eip" "eip" {
   count = var.disable_nat_gateway ? 0 : local.num_azs
 
   domain = "vpc"
-  tags   = merge({ "Vendor" = "StreamNative", Name = format("%s-eip-%s", var.vpc_name, count.index) }, var.tags)
+  tags   = merge({ "Vendor" = "StreamNative", Name = format("%s-eip-%s", var.vpc_name, count.index) }, local.tags)
 
   depends_on = [aws_internet_gateway.gw]
   lifecycle {
@@ -85,7 +86,7 @@ resource "aws_nat_gateway" "nat_gw" {
 
   allocation_id = aws_eip.eip[count.index].id
   subnet_id     = aws_subnet.public[count.index].id
-  tags          = merge({ "Vendor" = "StreamNative", Name = format("%s-ngw-%s", var.vpc_name, count.index) }, var.tags)
+  tags          = merge({ "Vendor" = "StreamNative", Name = format("%s-ngw-%s", var.vpc_name, count.index) }, local.tags)
 
   lifecycle {
     ignore_changes = [tags]
@@ -96,7 +97,7 @@ resource "aws_route_table" "public_route_table" {
   count = 1
 
   vpc_id = aws_vpc.vpc.id
-  tags   = merge({ "Vendor" = "StreamNative", "Type" = "public", Name = format("%s-public-rtb", var.vpc_name) }, var.tags)
+  tags   = merge({ "Vendor" = "StreamNative", "Type" = "public", Name = format("%s-public-rtb", var.vpc_name) }, local.tags)
 
   lifecycle {
     ignore_changes = [tags]
@@ -122,7 +123,7 @@ resource "aws_route_table" "private_route_table" {
   count = var.disable_nat_gateway ? 0 : local.num_azs
 
   vpc_id = aws_vpc.vpc.id
-  tags   = merge({ "Vendor" = "StreamNative", "Type" = "private", Name = format("%s-private-rtb-%s", var.vpc_name, count.index) }, var.tags)
+  tags   = merge({ "Vendor" = "StreamNative", "Type" = "private", Name = format("%s-private-rtb-%s", var.vpc_name, count.index) }, local.tags)
 
   lifecycle {
     ignore_changes = [tags]
@@ -166,8 +167,5 @@ resource "aws_vpc_endpoint" "s3_gateway_endpoint" {
 }
 POLICY
 
-  tags = {
-    Name   = "${var.vpc_name}-s3-gateway-endpoint"
-    Vendor = "StreamNative"
-  }
+  tags = merge({ "Vendor" = "StreamNative", Name = "${var.vpc_name}-s3-gateway-endpoint" }, local.tags)
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -73,7 +73,13 @@ variable "public_subnet_auto_ip" {
 
 variable "tags" {
   default     = {}
-  description = "Additional to apply to the resources. Note that this module sets the tags Name, Type, and Vendor by default. They can be overwritten, but it is not recommended."
+  description = "Deprecated: use additional_tags instead."
+  type        = map(string)
+}
+
+variable "additional_tags" {
+  default     = {}
+  description = "Additional tags to apply to the resources. Note that this module sets the tags Name, Type, and Vendor by default. They can be overwritten, but it is not recommended."
   type        = map(string)
 }
 


### PR DESCRIPTION
### Motivation

The existing `extra_aws_tags` variable in `modules/dns-bucket` and `extra_aws_tags`/`tags` variables in `modules/vpc` are inconsistently named across our Terraform module suite. This PR standardizes on `additional_tags` as the canonical variable name for passing extra resource tags, matching the convention already used in the root module (`main.tf`, `variables.tf`).

This change supports an ongoing migration where callers can transition from `extra_aws_tags`/`tags` to `additional_tags` without a breaking change.

### Modifications

- **`modules/dns-bucket/variables.tf`**: Added `additional_tags` variable. Deprecated `extra_aws_tags`. Updated `local.tags` to merge both (`extra_aws_tags` then `additional_tags`, so `additional_tags` takes precedence during transition).
- **`modules/vpc/variables.tf`**: Added `additional_tags` variable. Deprecated `tags`. Added `local.tags` that merges both.
- **`modules/vpc/main.tf`**: Updated all resource tag expressions to use `local.tags` instead of `var.tags` directly.

Backward compatible — existing callers passing `extra_aws_tags` or `tags` continue to work unchanged.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc`

  No user-facing behavior changes — variable additions with backward-compatible defaults.