### PR TITLE
feat(iam): manage AWS Load Balancer Controller policy inline

### DIFF
--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -48,6 +48,7 @@ No modules.
 | [aws_iam_role.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.loki](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.velero](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.irsa_s3_rw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -80,7 +81,7 @@ No modules.
 | <a name="input_enable_loki"></a> [enable\_loki](#input\_enable\_loki) | Enable loki for logging. If set to false, no loki resources will be created. | `bool` | `true` | no |
 | <a name="input_enable_velero"></a> [enable\_velero](#input\_enable\_velero) | Enable velero for backups. If set to false, no velero resources will be created. | `bool` | `false` | no |
 | <a name="input_extra_aws_tags"></a> [extra\_aws\_tags](#input\_extra\_aws\_tags) | extra aws tags to add to any resources | `map(string)` | `{}` | no |
-| <a name="input_load_balancer_policy_arn_override"></a> [load\_balancer\_policy\_arn\_override](#input\_load\_balancer\_policy\_arn\_override) | Override the runtime policy arn, otherwise will construct an arn | `string` | `""` | no |
+| <a name="input_load_balancer_policy_arn_override"></a> [load\_balancer\_policy\_arn\_override](#input\_load\_balancer\_policy\_arn\_override) | Optional additional managed policy ARN to attach to the AWS Load Balancer Controller role. The default controller policy is managed inline by bootstrap. | `string` | `""` | no |
 | <a name="input_loki_bucket"></a> [loki\_bucket](#input\_loki\_bucket) | The name of the AWS S3 bucket to use for Loki | `string` | n/a | yes |
 | <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | The oidc issuer for the cluster | `string` | n/a | yes |
 | <a name="input_permissions_boundary_arn_override"></a> [permissions\_boundary\_arn\_override](#input\_permissions\_boundary\_arn\_override) | Override the permission boundary arn, otherwise will construct an arn | `string` | `""` | no |

--- a/modules/iam/aws_load_balancer_controller.tf
+++ b/modules/iam/aws_load_balancer_controller.tf
@@ -1,6 +1,6 @@
 data "aws_iam_policy_document" "aws_load_balancer_controller_sts" {
   provider = aws.target
-  
+
   statement {
     actions = [
       "sts:AssumeRoleWithWebIdentity"
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "aws_load_balancer_controller_sts" {
 }
 
 resource "aws_iam_role" "aws_load_balancer_controller" {
-  provider             = aws.target
+  provider = aws.target
 
   name                 = format("%s-lbc-role", var.cluster_name)
   description          = format("Role used by IRSA and the KSA aws-load-balancer-controller on StreamNative Cloud EKS cluster %s", var.cluster_name)
@@ -29,9 +29,276 @@ resource "aws_iam_role" "aws_load_balancer_controller" {
   tags                 = local.tags
 }
 
+resource "aws_iam_role_policy" "aws_load_balancer_controller" {
+  provider = aws.target
+
+  name_prefix = "AWSLoadBalancerController"
+  role        = aws_iam_role.aws_load_balancer_controller.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:CreateServiceLinkedRole"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "iam:AWSServiceName" = "elasticloadbalancing.amazonaws.com"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeInstances",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeTags",
+          "ec2:GetCoipPoolUsage",
+          "ec2:DescribeCoipPools",
+          "ec2:GetSecurityGroupsForVpc",
+          "ec2:DescribeIpamPools",
+          "ec2:DescribeRouteTables",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeListenerCertificates",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeTags",
+          "elasticloadbalancing:DescribeTrustStores",
+          "elasticloadbalancing:DescribeListenerAttributes",
+          "elasticloadbalancing:DescribeCapacityReservation"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "cognito-idp:DescribeUserPoolClient",
+          "acm:ListCertificates",
+          "acm:DescribeCertificate",
+          "iam:ListServerCertificates",
+          "iam:GetServerCertificate",
+          "waf-regional:GetWebACL",
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:AssociateWebACL",
+          "waf-regional:DisassociateWebACL",
+          "wafv2:GetWebACL",
+          "wafv2:GetWebACLForResource",
+          "wafv2:AssociateWebACL",
+          "wafv2:DisassociateWebACL",
+          "shield:GetSubscriptionState",
+          "shield:DescribeProtection",
+          "shield:CreateProtection",
+          "shield:DeleteProtection"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Vendor" = "StreamNative"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateSecurityGroup"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateTags"
+        ]
+        Resource = "arn:${local.aws_partition}:ec2:*:*:security-group/*"
+        Condition = {
+          StringEquals = {
+            "ec2:CreateAction" = "CreateSecurityGroup"
+          }
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:CreateTags",
+          "ec2:DeleteTags"
+        ]
+        Resource = "arn:${local.aws_partition}:ec2:*:*:security-group/*"
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster"  = "true"
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DeleteSecurityGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+          StringEquals = {
+            "aws:ResourceTag/Vendor" = "StreamNative"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:DeleteRule"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ]
+        Resource = [
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ]
+        Condition = {
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster"  = "true"
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:RemoveTags"
+        ]
+        Resource = [
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:listener/net/*/*/*",
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:listener/app/*/*/*",
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:ModifyListenerAttributes",
+          "elasticloadbalancing:ModifyCapacityReservation",
+          "elasticloadbalancing:ModifyIpPools"
+        ]
+        Resource = "*"
+        Condition = {
+          Null = {
+            "aws:ResourceTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags"
+        ]
+        Resource = [
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:targetgroup/*/*",
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+          "arn:${local.aws_partition}:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "elasticloadbalancing:CreateAction" = [
+              "CreateTargetGroup",
+              "CreateLoadBalancer"
+            ]
+          }
+          Null = {
+            "aws:RequestTag/elbv2.k8s.aws/cluster" = "false"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets"
+        ]
+        Resource = "arn:${local.aws_partition}:elasticloadbalancing:*:*:targetgroup/*/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:SetWebAcl",
+          "elasticloadbalancing:ModifyListener",
+          "elasticloadbalancing:AddListenerCertificates",
+          "elasticloadbalancing:RemoveListenerCertificates",
+          "elasticloadbalancing:ModifyRule",
+          "elasticloadbalancing:SetRulePriorities"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy_attachment" "aws_load_balancer_controller" {
-  provider   = aws.target
+  count    = var.load_balancer_policy_arn_override != "" ? 1 : 0
+  provider = aws.target
 
   role       = aws_iam_role.aws_load_balancer_controller.name
-  policy_arn = local.default_lb_policy_arn
+  policy_arn = var.load_balancer_policy_arn_override
 }

--- a/modules/iam/locals.tf
+++ b/modules/iam/locals.tf
@@ -14,7 +14,6 @@ locals {
 
   permissions_boundary_arn   = var.permissions_boundary_arn_override != "" ? var.permissions_boundary_arn_override : "arn:${local.aws_partition}:iam::${local.account_id}:policy/StreamNative/StreamNativeCloudPermissionBoundary"
   default_service_policy_arn = var.runtime_policy_arn_override != "" ? var.runtime_policy_arn_override : "arn:${local.aws_partition}:iam::${local.account_id}:policy/StreamNative/StreamNativeCloudRuntimePolicy"
-  default_lb_policy_arn      = var.load_balancer_policy_arn_override != "" ? var.load_balancer_policy_arn_override : "arn:${local.aws_partition}:iam::${local.account_id}:policy/StreamNative/StreamNativeCloudLBPolicy"
 
   tags = merge({
     "Vendor"       = "StreamNative"

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -27,7 +27,7 @@ variable "runtime_policy_arn_override" {
 
 variable "load_balancer_policy_arn_override" {
   default     = ""
-  description = "Override the runtime policy arn, otherwise will construct an arn"
+  description = "Optional additional managed policy ARN to attach to the AWS Load Balancer Controller role. The default controller policy is managed inline by bootstrap."
   type        = string
 }
 
@@ -43,7 +43,7 @@ variable "cluster_node_group_iam_role_arn" {
 
 variable "enable_velero" {
   type        = bool
-  default     = false 
+  default     = false
   description = "Enable velero for backups. If set to false, no velero resources will be created."
 }
 


### PR DESCRIPTION
### Motivation

Currently, the AWS Load Balancer Controller IAM role is created, but the policy must be provided via an override or managed externally. This change manages the default AWS Load Balancer Controller policy inline within the IAM module, ensuring that the controller has the necessary permissions by default when the role is created.

### Modifications

- Added `aws_iam_role_policy.aws_load_balancer_controller` in `modules/iam/aws_load_balancer_controller.tf` to define the controller policy inline.
- Updated `load_balancer_policy_arn_override` variable description in `modules/iam/variables.tf` to clarify that it's now an optional additional policy.
- Updated `modules/iam/README.md` to reflect the changes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `terraform plan` in consuming modules.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
- [x] `no-need-doc` 
  
  Managed inline in Terraform module README.
